### PR TITLE
feat: Adds skeleton for fitting models; references on LIME/Shapely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ data/
 # Emacs files
 \#*
 *~
+
+# Quarto files
+index.xml
+index.subarticle.xml
+index.docx

--- a/index.qmd
+++ b/index.qmd
@@ -186,6 +186,8 @@ A summary of the variables that are available in this data set can be found in @
 #| warning: false
 #| tbl-caption: "Overall summary of all variables in the Sheffield dataset."
 df_summary <- df |>
+  ## NB - We drop the study_id its not a variable, rather its an identifier
+  dplyr::select(!(study_id)) |>
   dplyr::ungroup() |>
   gtsummary::tbl_summary(
     type = all_continuous() ~ "continuous2",
@@ -278,8 +280,17 @@ cv_loo <- rsample::loo_cv(train)
 thyroid_recipe <- recipes::recipe(final_pathology ~ gender + size_nodule_mm + age_at_scan + palpable_nodule +
   rapid_enlargment + thy_classification, data = train) |>
   recipes::step_num2factor(final_pathology, levels = c("Benign", "Malignant")) |>
-  recipes::step_dummy(gender, asa_score, smoking_status, nodule_fna_thy) |>
+  recipes::step_dummy(gender, palpable_nodule, rapid_enlargment, thy_classification) |>
   recipes::step_normalize(all_numeric())
+```
+
+```{r}
+#| label: workflow
+#| eval: true
+#| echo: true
+#| output: false
+thyroid_workflow <- workflows::workflow() |>
+  workflows::add_recipe(thyroid_recipe)
 ```
 
 ### Modelling
@@ -294,17 +305,327 @@ Results of the various modelling go here. Each section will show the results alo
 
 #### LASSO / Elastic Net
 
+```{r}
+#| label: lasso
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+## Specify the LASSO model using parsnip, the key here is the use of the glmnet engine which is the R package for
+## fitting LASSO regression. Technically the package fits Elastic Net but with a mixture value of 1 it is equivalent to
+## a plain LASSO (mixture value of 0 is equivalent to Ridge Regression in an Elastic Net)
+tune_spec_lasso <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 1) |>
+  parsnip::set_engine("glmnet")
+
+## Tune the LASSO parameters via cross-validation
+lasso_grid <- tune::tune_grid(
+  object = workflows::add_model(thyroid_workflow, tune_spec_lasso),
+  resamples = cv_folds,
+  grid = dials::grid_regular(penalty(), levels = 50)
+)
+
+## K-fold best fit for LASSO
+lasso_kfold_roc_auc <- lasso_grid |>
+  tune::select_best(metric = "roc_auc")
+
+## Fit the final LASSO model
+final_lasso_kfold <- tune::finalize_workflow(
+  workflows::add_model(thyroid_workflow, tune_spec_lasso),
+  lasso_kfold_roc_auc
+)
+```
+
+```{r}
+#| label: lasso-kfold-eval-importance
+#| purl: true
+#| eval: false
+#| echo: true
+#| output: true
+final_lasso_kfold |>
+  fit(train) |>
+  hardhat::extract_fit_parsnip() |>
+  vip::vi(lambda = lasso_kfold_roc_auc$penalty) |>
+  dplyr::mutate(
+    Importance = abs(Importance),
+    Variable = fct_reorder(Variable, Importance)
+  ) |>
+  ggplot(mapping = aes(x = Importance, y = Variable, fill = Sign)) +
+  geom_col() +
+  dark_theme_minimal()
+```
+
+``` {r}
+#| label: lasso-save
+#| purl: true
+#| eval: false
+#| echo: true
+#| output: false
+save(lasso_tune_spec, lasso_grid, final_lasso, lasso_highest_roc_auc,
+  file = "data/r/lasso.RData"
+)
+```
+
+#### Elastic Net
+
+
+```{r}
+#| label: elastic-net-specification
+#| purl: true
+#| eval: false
+#| echo: true
+#| output: false
+## Elastic Net model specification, as with LASSO it uses glmnet package but the mixture is 0.5 which is 50% LASSO (L1
+## regularisation) and 50% Ridge Regression (L2 regularisation)
+elastic_net_tune_spec <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 0.5) |>
+  parsnip::set_engine("glmnet")
+
+## Tune the model using `tune::tune_grid()` (https://tune.tidymodels.org/reference/tune_grid.html), calculates the
+## accuracy or the Root Mean Square Error
+elastic_net_grid <- tune::tune_grid(
+  object = workflows::add_model(thyroid_workflow, elastic_net_tune_spec),
+  resamples = cv_folds,
+  grid = dials::grid_regular(penalty(), levels = 50)
+)
+
+## Perform K-fold cross validation
+elastic_net_highest_roc_auc <- elastic_net_grid |>
+  tune::select_best(metric = "roc_auc")
+
+## Make the final best fit based on K-fold cross validation
+final_elastic_net <- tune::finalize_workflow(
+  workflows::add_model(thyroid_workflow, elastic_net_tune_spec),
+  elastic_net_highest_roc_auc
+)
+```
+
+```{r}
+#| label: elastic-net-kfold-eval-importance
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: true
+final_elastic_net |>
+  fit(train) |>
+  hardhat::extract_fit_parsnip() |>
+  vip::vi(lambda = elastic_net_highest_roc_auc$penalty) |>
+  dplyr::mutate(
+    Importance = abs(Importance),
+    Variable = fct_reorder(Variable, Importance)
+  ) |>
+  ggplot(mapping = aes(x = Importance, y = Variable, fill = Sign)) +
+  geom_col() +
+  dark_theme_minimal()
+```
+
+``` {r}
+#| label: elastic-net-save
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+save(elastic_net_tune_spec, elastic_net_grid, final_elastic_net, elastic_net_highest_roc_auc,
+  file = "data/r/elastic_net.RData"
+)
+```
+
+
 #### Random Forest
+
+``` {r}
+#| label: random-forest-specify
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+## Specify the Random Forest model
+rf_tune <- parsnip::rand_forest(
+  mtry = tune(),
+  trees = 100,
+  min_n = tune()
+) |>
+  set_mode("classification") |>
+  set_engine("ranger", importance = "impurity")
+
+
+## Tune the parameters via Cross-validation
+rf_grid <- tune::tune_grid(
+  add_model(thyroid_workflow, rf_tune),
+  resamples = cv_folds, ## cv_loo,
+  grid = grid_regular(mtry(range = c(5, 10)), # smaller ranges will run quicker
+    min_n(range = c(2, 25)),
+    levels = 3
+  )
+)
+
+## Get the best fitting model with the highest ROC AUC
+rf_highest_roc_auc <- rf_grid |>
+  select_best("roc_auc")
+final_rf <- tune::finalize_workflow(
+  add_model(thyroid_workflow, rf_tune),
+  rf_highest_roc_auc
+)
+```
+
+``` {r}
+#| label: rf-kfold-eval-importance
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: true
+final_rf |>
+  fit(train) |>
+  hardhat::extract_fit_parsnip() |>
+  vip::vi(lambda = final_rf$penalty) |>
+  dplyr::mutate(
+    Importance = abs(Importance),
+    Variable = fct_reorder(Variable, Importance)
+  ) |>
+  ggplot(mapping = aes(x = Importance, y = Variable, fill = Sign)) +
+  geom_col() +
+  dark_theme_minimal()
+```
+
+``` {r}
+#| label: random-forest-save
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+save(random_forest_tune_spec, random_forest_grid, final_random_forest, random_forest_highest_roc_auc,
+  file = "data/r/random_forest.RData"
+)
+```
 
 #### Gradient Boosting
 
+``` {r}
+#| label: xgboost-model
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+## Specify the Gradient boosting model
+xgboost_model <- parsnip::boost_tree(
+  mode = "classification",
+  trees = 100,
+  min_n = tune(),
+  tree_depth = tune(),
+  learn_rate = tune(),
+  loss_reduction = tune()
+) |>
+  set_engine("xgboost", objective = "binary:logistic")
+
+## Specify the models tuning parameters using the `dials` package along (https://dials.tidymodels.org/) with the grid
+## space. This helps identify the hyperparameters with the lowest prediction error.
+xgboost_params <- dials::parameters(
+  min_n(),
+  tree_depth(),
+  learn_rate(),
+  loss_reduction()
+)
+xgboost_grid <- dials::grid_max_entropy(
+  xgboost_params,
+  size = 10
+)
+
+## Tune the model via cross-validation
+xgboost_tuned <- tune::tune_grid(workflows::add_model(thyroid_workflow, spec = xgboost_model),
+  resamples = cv_folds,
+  grid = xgboost_grid,
+  metrics = yardstick::metric_set(roc_auc, accuracy, ppv),
+  control = tune::control_grid(verbose = FALSE)
+)
+```
+
+
+
+``` {r}
+#| label: xgboost-final
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+## We get the best final fit from the Gradient Boosting model.
+xgboost_highest_roc_auc <- xgboost_tuned |>
+  tune::select_best("roc_auc")
+final_xgboost <- tune::finalize_workflow(
+  add_model(thyroid_workflow, xgboost_model),
+  xgboost_highest_roc_auc
+)
+```
+
+``` {r}
+#| label: xgboost-save
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+save(xgboost_tune_spec, xgboost_grid, final_xgboost, xgboost_highest_roc_auc,
+  file = "data/r/xgboost.RData"
+)
+```
+
 #### SVM
+
+``` {r}
+#| label: svm-specify
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+## Specify
+svm_tune_spec <- parsnip::svm_rbf(cost = tune()) |>
+  set_engine("kernlab") |>
+  set_mode("classification")
+
+## The hyperparameters are then tuned, in effect running the model in multiple subsets of the cross-validation to
+## get a "best fit".
+svm_grid <- tune::tune_grid(
+  workflows::add_model(thyroid_workflow, svm_tune_spec),
+  resamples = cv_folds, ## cv_loo,
+  grid = dials::grid_regular(cost(), levels = 20)
+)
+
+## The best fit is selected and fit to the overall training data set.
+svm_highest_roc_auc <- svm_grid |>
+  tune::select_best("roc_auc")
+final_svm <- tune::finalize_workflow(
+  add_model(thyroid_workflow, svm_tune_spec),
+  svm_highest_roc_auc
+)
+
+
+## Finally an assessment is made on the accuracy -->
+tune::last_fit(final_svm, split,
+  metrics = yardstick::metric_set(roc_auc, accuracy, ppv)
+) |>
+  tune::collect_metrics()
+```
+
+```{r}
+#| label: svm-save
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+save(svm_tune_spec, svm_grid, final_svm, svm_highest_roc_auc,
+  file = "data/r/svm.RData"
+)
+```
+
+#### Explainability
+
+Which factors are important to classification can be assessed not just by the "importance" but by methods know as
+[LIME](https://search.r-project.org/CRAN/refmans/lime/html/lime-package.html) (Local Interpretable Model-Agnostic
+Explanations)  @ribeiro2016 and [Shapley
+values](https://shap.readthedocs.io/en/latest/example_notebooks/overviews/An%20introduction%20to%20explainable%20AI%20with%20Shapley%20values.html)
+@lundberg2017
 
 #### Comparision
 
 Comparing the sensitivity of the different models goes here.
 
-+ Table of sensitivit/specificit/other metrics.
++ Table of sensitivity/specificity/other metrics.
 + ROC curves
 
 ## Conclusion

--- a/r/shf_thy_nod.R
+++ b/r/shf_thy_nod.R
@@ -107,6 +107,10 @@ df <- df |>
       ~ as.factor(.x)
     ))
 
+## ns-rse (2024-04-30) : A Check should be made for duplicated data and any such duplicates removed, even if you think
+## there shouldn't be or aren't any duplicates in a dataset it is a simple step to make such a check and remove any that
+## are found.
+df <- unique(df)
 
 ## Save a copy of the clean data (df) for loading and using in analysis
 saveRDS(df, file = paste(r_dir, "clean.rds", sep = "/"))

--- a/references.bib
+++ b/references.bib
@@ -1,4 +1,28 @@
-﻿@article{smith2018,
+﻿@article{lundberg2017,
+title = {A Unified Approach to Interpreting Model Predictions},
+author = {Lundberg, Scott M and Lee, Su-In},
+booktitle = {Advances in Neural Information Processing Systems 30},
+editor = {I. Guyon and U. V. Luxburg and S. Bengio and H. Wallach and R. Fergus and S. Vishwanathan and R. Garnett},
+pages = {4765--4774},
+year = {2017},
+publisher = {Curran Associates, Inc.},
+url = {http://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions.pdf}
+}
+
+
+@article{ribeiro2016,
+	author = {Ribeiro, Marco Tulio and Singh, Sameer and Guestrin, Carlos},
+	title = {{"Why Should I Trust You?": Explaining the Predictions of Any Classifier}},
+	journal = {arXiv},
+	year = {2016},
+	month = feb,
+	eprint = {1602.04938},
+	doi = {10.48550/arXiv.1602.04938},
+	keywords = {Machine Learning (cs.LG), Artificial Intelligence (cs.AI), Machine Learning (stat.ML)},
+	abstract = {{Despite widespread adoption, machine learning models remain mostly black boxes. Understanding the reasons behind predictions is, however, quite important in assessing trust, which is fundamental if one plans to take action based on a prediction, or when choosing whether to deploy a new model. Such understanding also provides insights into the model, which can be used to transform an untrustworthy model or prediction into a trustworthy one. In this work, we propose LIME, a novel explanation technique that explains the predictions of any classifier in an interpretable and faithful manner, by learning an interpretable model locally around the prediction. We also propose a method to explain models by presenting representative individual predictions and their explanations in a non-redundant way, framing the task as a submodular optimization problem. We demonstrate the flexibility of these methods by explaining different models for text (e.g. random forests) and image classification (e.g. neural networks). We show the utility of explanations via novel experiments, both simulated and with human subjects, on various scenarios that require trust: deciding if one should trust a prediction, choosing between models, improving an untrustworthy classifier, and identifying why a classifier should not be trusted.}}
+}
+
+@article{smith2018,
 	author = {Smith, Gary},
 	title = {{Step away from stepwise}},
 	journal = {J. Big Data},


### PR DESCRIPTION
+ Adds skeleton code chunks for fitting a range of models (currently disabled, they fail!).
+ Adds a section on assessing what values are important for classification using LIME and Shapely values and includes citations.
+ Adds a line to `r/shf_thy_nod.R` that explicitly drops duplicate observations.