### PR TITLE
chore: Tidying table links; rendering LASSO section

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -18,3 +18,7 @@ format:
 
 execute:
   freeze: true
+
+render:
+  - "*.qmd"
+  - "!sections/"

--- a/index.qmd
+++ b/index.qmd
@@ -47,6 +47,8 @@ bibliography: references.bib
 citation:
   container-title: "Sheffield study on thyroid nodules"
 number-sections: true
+notebook-preview-options:
+  preview: false
 ---
 
 ```{r}
@@ -224,12 +226,16 @@ support vectors are the only data points that have an influence on the maximum m
 ## Results
 
 ```{r}
+#| label: n_obs
+#| eval: true
+#| echo: false
+#| warning: false
 n_obs <- nrow(df)
 ```
 
 
 ```{r}
-#| label: patient_demographics
+#| label: tbl-patient-demographics
 #| eval: true
 #| echo: false
 #| warning: false
@@ -243,11 +249,11 @@ patient_demo
 print(colnames(patient_demo))
 ```
 
-@patient_demographics shows the demographics of patients included in this study. A total of `r n_obs` patients were included in
+@tbl-patient-demographics shows the demographics of patients included in this study. A total of `r n_obs` patients were included in
 this study with a median (IQR) age of  `r gtsummary::inline_text(patient_demo, variable="age_at_scan")`.
 
 ```{r}
-#| label: clinical_characteristics
+#| label: tbl-clinical-characteristics
 #| eval: true
 #| echo: false
 #| warning: false
@@ -272,10 +278,10 @@ clinical_charac
 print(colnames(clinical_charac))
 ```
 
-@clinical_characteristics shows the distribution of clinical variables evaluated between benign and malignant thyroid nodules.
+@tbl-clinical-characteristics shows the distribution of clinical variables evaluated between benign and malignant thyroid nodules.
 
 ```{r}
-#| label: biochem_variables
+#| label: tbl-biochem-variables
 #| eval: true
 #| echo: false
 #| warning: false
@@ -294,7 +300,7 @@ print(colnames(biochem_vars))
 ```
 
 ```{r}
-#| label: ultrasound_characteristics
+#| label: tbl-ultrasound-characteristics
 #| eval: true
 #| echo: false
 #| warning: false
@@ -314,7 +320,7 @@ print(colnames(ultrasound_char))
 ```
 
 ```{r}
-#| label: cytology_characteristics
+#| label: tbl-cytology-characteristics
 #| eval: true
 #| echo: false
 #| warning: false
@@ -387,21 +393,12 @@ that there are `r gtsummary::inline_text(df_summary, variable="final_pathology",
 instances where the `final_pathology` is not known which reduces the sample size to
 `r df |> dplyr::filter(!is.na(final_pathology)) |> nrow()`.
 
-**IMPORTANT** You will probably want to have a the following section included which excludes those with missing
-`final_pathology`, they can't contribute anything to the modelling.
+### Modelling
 
-
-**IMPORTANT** Once you have decided which variables you want to include in your analysis you should determine how many
-individuals have complete data for all of these, this _will_ reduce your sample size available. You could add that to
-this section.
-
-The predictor variables selected for inclusion were age, gender, ethnicity, incidental nodule, palpable nodule, rapid
-enlargement, compressive symptoms, hypertension, vocal cord paresis, Graves' disease, Hashimotos' thyroiditis, family
-history of thyroid cancer, exposure to radiation, serum albumin, serum TSH, serum monocytes, serum lymphocytes, BTA U
-classification, nodule size, FNA Thy classification, final pathology.
+The predictor variables selected to predict `final_pathology` are shown in @tbl-predictors
 
 ```{r}
-#| label: predictors-evaluated
+#| label: tbl-predictors
 #| purl: true
 #| eval: true
 #| echo: false
@@ -434,7 +431,9 @@ df_predictors_evaluated
 #| echo: false
 #| output: false
 ## Prefer tidymodel commands (although in most places we use the convention <pkg>::<function>())
-tidymodels_prefer()
+library(tidyverse)
+library(tidymodels)
+tidymodels::tidymodels_prefer()
 set.seed(5039378)
 
 ## This is the point at which you should subset your data for those who have data available for the variables of
@@ -465,7 +464,12 @@ df_complete <- df |>
     cervical_lymphadenopathy,
     thy_classification,
     final_pathology) |>
-dplyr::filter(if_any(everything(), is.na))
+## @ns-rse 2024-06-14 :
+## I would consider removing this dplyr::filter() and instead using the recipes::step_filter_missing() as is now in
+## place below
+## dplyr::filter(if_any(everything(), is.na))
+## Instead I think it might be useful to remove individuals who do not have a value for final_pathology here
+  dplyr::filter(!is.na(final_pathology))
 
 ## Use the df_complete rather than df as this subset have data for all the variables of interest.
 split <- rsample::initial_split(df_complete, prop = 0.75)
@@ -473,9 +477,6 @@ train <- rsample::training(split)
 test <- rsample::testing(split)
 ```
 
-view(df_complete)
-view(df)
-<!--this still has 1299 data set, fairly complete or analysis not applied-->
 
 ```{r}
 #| label: cv-vfold
@@ -505,7 +506,19 @@ cv_loo <- rsample::loo_cv(train)
 ## (the outcome of interest) is in this case the `final_pathology`, whether individuals have malignant or benign tumors,
 ## this appears on the left-hand side of the equation (before the tilde `~`). On the right of the equation are the
 ## predictor or dependant variables
-thyroid_recipe <- recipes::recipe(final_pathology ~ age_at_scan + gender + ethnicity + incidental_nodule + palpable_nodule + rapid_enlargment + compressive_symtoms + hypertension + vocal_cord_paresis + graves_disease + hashimotos_thyroiditis + family_history_thyroid_cancer + exposure_radiation + albumin + tsh_value + lymphocytes + monocyte + bta_u_classification + size_nodule_mm + cervical_lymphadenopathy + thy_classification, data = train) |>
+##
+## @ns-rse 2024-06-14 :
+## Because we have used dplyr::select() to choose _just_ the columns of interest we can use the '.'
+## notation to refer to "all other variables" as being predictors. This is useful as it saves duplication of writing
+## everything out which leaves scope for some being missed.
+thyroid_recipe <- recipes::recipe(final_pathology ~ ., data = train) |>
+  ## @ns-rse 2024-06-14 :
+  ## This step can be used to filter observations with missing data, see the manual pages for more details
+  ## https://recipes.tidymodels.org/reference/step_filter_missing.html
+  recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+  ## @ns-rse 2024-06-14 :
+  ## We first normalise the data _before_ we generate dummies otherwise the dummies, which are numerical, get normalised
+  ## too
   recipes::step_normalize(recipes::all_numeric_predictors()) |>
   recipes::step_dummy(recipes::all_nominal_predictors())
 ```
@@ -517,9 +530,9 @@ thyroid_recipe <- recipes::recipe(final_pathology ~ age_at_scan + gender + ethni
 #| output: false
 thyroid_workflow <- workflows::workflow() |>
   workflows::add_recipe(thyroid_recipe)
-```
 
-### Modelling
+```
+<!-- {{< include sections/recipe.qmd >}} -->
 
 A total of `r df_complete |> nrow()` patients had complete data for the selected predictor variables (see
 @tbl-predictors).

--- a/r/shf_thy_nod.R
+++ b/r/shf_thy_nod.R
@@ -55,37 +55,9 @@ var_labels <- c(
 df <- tibble(raw_data)
 Hmisc::label(df) <- as.list(var_labels[match(names(df), names(var_labels))])
 
-## Convert Yes/No columns into logical FALSE/TRUE.
-## 1. Make a list of all Yes/No columns (again sorted alphabetically, its easier to read)
-binary_cols <- c(
-  "cervical_lymphadenopathy",
-  "compressive_symtoms",
-  "exposure_radiation",
-  "family_history_thyroid_cancer",
-  "fna_done",
-  "graves_disease",
-  "hashimotos_thyroiditis",
-  "hypertension",
-  "incidental_nodule",
-  "palpable_nodule",
-  "rapid_enlargment",
-  "repeat_fna_done",
-  "repeat_ultrasound",
-  "solitary_nodule",
-  "vocal_cord_paresis"
-)
-## 2. Recode this list to "Yes" = TRUE; "No" = FALSE (Can't use as.logical() directly as that only works with variables
-##    coded as 0/1).
-df <- df |>
-    dplyr::mutate(dplyr::across(
-        dplyr::all_of(binary_cols),
-        ~ dplyr::recode(.x,
-             "Yes" = TRUE,
-             "No" = FALSE
-        )
-    ))
-
-## Convert character variables to factors
+## Convert character variables to factors, this now includes binary variables that are 'No'/'Yes' which will now be
+## treated as factors /nominal variables and the required dummies generated when we use
+## recipes::step_dummy(recipes::all_nominal_predictors()) to encode them to dummy variables.
 df <- df |>
     dplyr::mutate_if(is.character, as.factor)
 

--- a/sections/lasso.qmd
+++ b/sections/lasso.qmd
@@ -1,7 +1,7 @@
 
 
 ```{r}
-#| label: lasso
+#| label: lasso-tune
 #| purl: true
 #| eval: true
 #| echo: false
@@ -19,9 +19,23 @@ lasso_grid <- tune::tune_grid(
   grid = dials::grid_regular(penalty(), levels = 50)
 )
 
+```{r}
+#| label: lasso-best-fit
+#| purl: true
+#| eval: true
+#| echo: true
+#| output: true
 ## K-fold best fit for LASSO
 lasso_kfold_roc_auc <- lasso_grid |>
   tune::select_best(metric = "roc_auc")
+```
+
+```{r}
+#| label: lasso-final
+#| purl: true
+#| eval: true
+#| echo: true
+#| output: true
 
 ## Fit the final LASSO model
 final_lasso_kfold <- tune::finalize_workflow(


### PR DESCRIPTION
Some of the table links weren't working I think this was one of two possible reasons.

1. The `#| label:` value shouldn't have `_` (underscore) in them as Markdown treats such charactesr as special as they are used for marking text as _italics_.
2. In all the Quarto examples I have seen table labels all begin with `tbl-`.

I've corrected these and the tables are now correctly referenced and linked when rendered/previewed.

After tinkering with the `recipe::()` stages and removing some duplicated text to make it simpler we now...

1. Filter the variables of interest.
2. Remove individuals who are missing `final_pathology`
3. Setup a `recipe()` using the notation `final_pathology ~ .` where `.` means all other variables, which we selected in step  1.
4. Use `recipes::step_filter_missing()` to remove instances where `recipes::all_predictors()` are missing.
5. Use `recipes::step_normalize()` to normalise `recipes::all_numeric_predictors()`.
6. Use `recipes::step_dummy()` to generate dummies for `recipes::all_nominal_predictors()`. This last step now includes all binary `No`/`Yes` variables too.

I'm still not yet convinced everything is running perfectly smoothly, things to check would be the number of observations in the `df_complete` and the `train` and `test` data frames.

I did try splitting out the code that builds the recipe to its own `sections/recipe.qmd` and including it in the same manner as the `sections/lasso.qmd` is, but encountered errors when trying to preview as there is an attempt made to render notebooks from these files and that was for some reason failing (and I've not been able to work out why today).