### PR TITLE
changes to step_dummy & split LASSO to its own file

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,5 +1,7 @@
 project:
   type: manuscript
+  preview:
+    port: 4681
 
 manuscript:
   article: index.qmd
@@ -8,6 +10,10 @@ format:
   html:
     comments:
       hypothesis: true
+    toc: true
+    toc-depth: 4
+    toc-expand: 3
+    toc-title: "Table of Contents"
     toc-location: right
 
   docx: default

--- a/index.qmd
+++ b/index.qmd
@@ -168,10 +168,10 @@ Data was cleaned and analysed using the R Statistical Software @r_citation and t
 
 ### Modelling
 
-We used a selection of statistic modelling techniques to evaluate association between variables and thyroid cancer in patients with thyroid nodules.
-We used the training and test methodology to split the patient population into training and testing cohorts in a ratio
-of `r train`:`r test` and each model is fitted using the
-training cohort. This split ratio is generally used in traditional machine learning techniques. The training set of the
+We used a selection of statistic modelling techniques to evaluate association between variables and thyroid cancer in
+patients with thyroid nodules. The patient population was split into training and testing cohorts in a ratio
+of `r train`:`r test` and each model is fitted using the training cohort.
+This split ratio is generally used in traditional machine learning techniques. The training set of the
 data was used to estimate the relation between variables and thyroid cancer. The larger the training data, the better
 it is for the model to learn the trends. The test set was used to determine the accuracy of the model in predicting
 thyroid cancer; the bigger the test data the more confidence we have in the model prognostic values. We used simple
@@ -202,11 +202,13 @@ variables @steyerberg2001
 
 
 #### Random Forest
+
 To add reference
 The random forest plot is an extension of the decision tree methodology to reduce variance. Decision trees are very sensitive to the training data set and can lead to high variance; thus potential issues with generalisation of the model. The random forest plot selects random observation of the dataset to create multiple decision trees. Random variables are selected for each tree in the training of the data set. The aggregated output of the generated decision trees is then used to create an estimate.
 
 
 #### Gradient Boosting
+
 Gradient boosting is a machine learning algorithm that uses decision tree as a base model. The data is initially trained
 on this decision tree, but the initial prediction is weak, thus termed a weak based model. In gradient boosting the process
 is iterative; a sequence of decision trees is added to the initial tree. Each tree learns from the prior tree(s) to improve the model, increasing strength and minimising error.
@@ -404,38 +406,11 @@ The predictor variables selected to predict `final_pathology` are shown in @tbl-
 #| echo: false
 #| warning: false
 #| tbl-caption: "predictors-evaluated"
-df_predictors_evaluated <- df |>
-  ## dropped variables
-  dplyr::select(-any_of(c("study_id", "eligibility", "consistency_nodule", "repeat_ultrasound", "repeat_bta_u_classification", "fna_done", "repeat_fna_done", "repeat_thy_classification", "thyroid_surgery", "thyroid_histology_diagnosis"))) |>
-  dplyr::ungroup() |>
-  gtsummary::tbl_summary(
-    type = all_continuous() ~ "continuous2",
-    statistic = all_continuous() ~ c(
-      "{N_nonmiss}",
-      "{mean} ({sd})",
-      "{median} ({p25}, {p75})",
-      "{min}, {max}"
-    ),
-    percent="column",      # Include percentages for categorical variables by "column", "row" or "cell"
-    missing="always"           # Exclude missing, options are "no", "ifany" and "always"
-  ) |>
-  gtsummary::modify_caption("Variables evaluated in the model")
-df_predictors_evaluated
-```
-
-<!-- Section that sets up the modelling -->
-```{r}
-#| label: test-train-split
-#| purl: true
-#| eval: true
-#| echo: false
-#| output: false
-## Prefer tidymodel commands (although in most places we use the convention <pkg>::<function>())
-library(tidyverse)
-library(tidymodels)
-tidymodels::tidymodels_prefer()
-set.seed(5039378)
-
+## @ns-rse 2024-06-18:
+## We want this table to match the model, therefore rather than repeat ourselves we move the subsetting to give us
+## df_complete to here and assign to df_complete. This is then passed into gtsummary::tbl_summary() and is available for
+## the next code chunk.
+##
 ## This is the point at which you should subset your data for those who have data available for the variables of
 ## interest. The variables here should include the outcome `final_pathology` and the predictor variables that are set in
 ## the code chunk `recipe`. May want to move this to another earlier in the processing so that the number of rows can be
@@ -471,7 +446,37 @@ df_complete <- df |>
 ## Instead I think it might be useful to remove individuals who do not have a value for final_pathology here
   dplyr::filter(!is.na(final_pathology))
 
-## Use the df_complete rather than df as this subset have data for all the variables of interest.
+df_predictors_evaluated <- df_complete |>
+  dplyr::ungroup() |>
+  gtsummary::tbl_summary(
+    type = all_continuous() ~ "continuous2",
+    statistic = all_continuous() ~ c(
+      "{N_nonmiss}",
+      "{mean} ({sd})",
+      "{median} ({p25}, {p75})",
+      "{min}, {max}"
+    ),
+    percent="column",      # Include percentages for categorical variables by "column", "row" or "cell"
+    missing="always"           # Exclude missing, options are "no", "ifany" and "always"
+  ) |>
+  gtsummary::modify_caption("Variables evaluated in the model")
+df_predictors_evaluated
+```
+
+<!-- Section that sets up the modelling -->
+```{r}
+#| label: test-train-split
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: false
+## Prefer tidymodel commands (although in most places we use the convention <pkg>::<function>())
+library(tidyverse)
+library(tidymodels)
+tidymodels::tidymodels_prefer()
+set.seed(5039378)
+
+## Use df_complete rather than df as this subset have data for all the variables of interest.
 split <- rsample::initial_split(df_complete, prop = 0.75)
 train <- rsample::training(split)
 test <- rsample::testing(split)
@@ -542,7 +547,7 @@ Results of the various modelling go here. Each section will show the results alo
 + LIME/Shaply analysis for explanability of models
 
 
-#### LASSO / Elastic Net
+#### LASSO
 
 {{< include sections/lasso.qmd >}}
 

--- a/sections/lasso.qmd
+++ b/sections/lasso.qmd
@@ -4,8 +4,9 @@
 #| label: lasso-tune
 #| purl: true
 #| eval: true
-#| echo: false
+#| echo: true
 #| output: false
+#| cache: true
 ## Specify the LASSO model using parsnip, the key here is the use of the glmnet engine which is the R package for
 ## fitting LASSO regression. Technically the package fits Elastic Net but with a mixture value of 1 it is equivalent to
 ## a plain LASSO (mixture value of 0 is equivalent to Ridge Regression in an Elastic Net)
@@ -18,6 +19,23 @@ lasso_grid <- tune::tune_grid(
   resamples = cv_folds,
   grid = dials::grid_regular(penalty(), levels = 50)
 )
+```
+
+```{r}
+#| label: fig-lasso-tune-autoplot
+#| fig-cap: Autoplot of LASSO grid search
+#| purl: true
+#| eval: true
+#| echo: true
+#| output: true
+## Plot the tuning search results, see https://tune.tidymodels.org/reference/autoplot.tune_results.html
+##
+## This shows how the evaluation metrics change over time with each iteration of the Lasso (we know we are running a
+## LASSO because when we setup tune_spec_lasso the mixture = 1 when we define parsnip::logistic_reg()
+tune::autoplot(lasso_grid)
+```
+
+
 
 ```{r}
 #| label: lasso-best-fit
@@ -45,9 +63,10 @@ final_lasso_kfold <- tune::finalize_workflow(
 ```
 
 ```{r}
-#| label: lasso-kfold-eval-importance
+#| label: fig-lasso-kfold-eval-importance
+#| fig-cap: Importance of variables fitted using LASSO
 #| purl: true
-#| eval: false
+#| eval: true
 #| echo: true
 #| output: true
 final_lasso_kfold |>
@@ -63,13 +82,22 @@ final_lasso_kfold |>
   dark_theme_minimal()
 ```
 
+**NB** - We may wish to inspect the coefficients at each step of tuning. A related example of how to do this can be found in
+the [Tidymodels documentation](https://www.tidymodels.org/learn/) under the [Tuning a `glmnet`
+model](https://www.tidymodels.org/learn/models/coefficients/#tuning-a-glmnet-model). This would be desirable as it looks
+like only two features are selected as being important by this method and so rather than just accepting this I would
+want to investigate and see how the coefficients changed over iterations. Another useful resource is the
+[glmnet](https://glmnet.stanford.edu/articles/glmnet.html) documentation, although note that since we are using the
+Tidymodels framework the model `fit` is wrapped up inside (hence the above article on how to extract this information).
+
+
 ``` {r}
 #| label: lasso-save
 #| purl: true
-#| eval: false
+#| eval: true
 #| echo: true
 #| output: false
-save(lasso_tune_spec, lasso_grid, final_lasso, lasso_highest_roc_auc,
+save(tune_spec_lasso, lasso_grid, final_lasso_kfold, lasso_kfold_roc_auc,
   file = "data/r/lasso.RData"
 )
 ```


### PR DESCRIPTION
+ Updates `_quarto.yaml` to use a specific port on rendering and show deeper levels in the table of contents to aid
  navigation.
+ Suggestion on improving wording in methods to flow more naturally and reduce repetition.
+ Split the derivation of `df_complete` so it is derived once and used in the table of evaluated predictors and then in
  the recipe rather than having two separate sections that needed to be kept in-sync.
+ Enable `eval: true` on sections after fitting the LASSO so that results are shown for the importance. Added an
  `autoplot` and some notes on how the LASSO fitting can be further investigated.