### PR TITLE
Corrects invalid level of graves_disease; improve imputation and summary tables.

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -363,17 +363,16 @@ thyroid nodules.
 
 ### Data Description
 
-Details of data completeness and other descriptive aspects go here.
-
-
 
 A summary of the variables that are available in this data set can be found in @tbl-variables.
 
 
 ```{r}
+## @ns-rse (2024-07-18) - I have set this code chunk to _not_ be evaluated as it is mostly  duplicated in the summary of
+##                        imputed data.
 #| label: tbl-data-completeness
 #| purl: true
-#| eval: true
+#| eval: false
 #| echo: false
 #| warning: false
 #| tbl-caption: "Overall summary of all variables in the Sheffield dataset."
@@ -397,9 +396,10 @@ df_summary
 
 ```
 
-The completeness of the data is shown in @tbl-data-completeness . Where
-variables continuous (e.g. `age` or `size_nodule_mm`) basic summary statistics in the form of mean, standard deviation,
-median and inter-quartile range are given. For categorical variables that are logical `TRUE`/`FALSE`
+The completeness of the original data is shown in tables @tbl-imputation-summary-pmm, @tbl-imputation-summary-cart,
+@tbl-imputation-summary-rf, along with summaries from four rounds of imputation for each of three imputation methods.
+Where variables continuous (e.g. `age` or `size_nodule_mm`) basic summary statistics in the form of mean, standard
+deviation, median and inter-quartile range are given. For categorical variables that are logical `TRUE`/`FALSE`
 (e.g. `palpable_nodule`) the number of `TRUE` observations and the percentage (of those with observed data for that
 variable) are shown along with the number that are _Unknown_. For categorical variables such as `gender` percentages
 in each category are reported. For all variables an indication of the number of missing observations is also given and
@@ -418,14 +418,16 @@ instances where the `final_pathology` is not known which reduces the sample size
 
 ### Modelling
 
+**TODO** - And in light of having removed @tbl-data-completness in favour of the imputed datesets this too has been removed? (`@ns-rse` 2024-07-11).
 **TODO** - This table feels like duplication of @tbl-data-completeness, perhaps have just one? (`@ns-rse` 2024-07-11).
 
-The predictor variables selected to predict `final_pathology` are shown in @tbl-predictors
+<!-- The predictor variables selected to predict `final_pathology` are shown in @tbl-predictors -->
 
 ```{r}
+## @ns-rse (2024-07-18) - I've disabled this table from being evaluated.
 #| label: tbl-predictors
 #| purl: true
-#| eval: true
+#| eval: false
 #| echo: false
 #| warning: false
 #| tbl-caption: "Predictors evaluated in modelling."

--- a/r/shf_thy_nod.R
+++ b/r/shf_thy_nod.R
@@ -50,10 +50,19 @@ var_labels <- c(
   vocal_cord_paresis = "Vocal cord paresis"
   )
 
+## @ns-rse 2024-07-18 : I noticed there is a single instance of graves_disease that is "no" rather than "No", we correct
+## that now
+raw_data<- raw_data|>
+    dplyr::mutate(graves_disease = case_when(graves_disease == "no" ~ "No",
+        .default = graves_disease
+    ))
+
+
 ## Make a copy of the raw data so that comparisons can be made between it and the cleaned dataset. This allows checking
 ## that no mistakes have been made
 df <- tibble(raw_data)
 Hmisc::label(df) <- as.list(var_labels[match(names(df), names(var_labels))])
+
 
 ## Convert character variables to factors, this now includes binary variables that are 'No'/'Yes' which will now be
 ## treated as factors /nominal variables and the required dummies generated when we use

--- a/sections/_imputation.qmd
+++ b/sections/_imputation.qmd
@@ -21,35 +21,52 @@ cores = imputations
 mice_pmm <- df_complete |>
     dplyr::select(-final_pathology) |>    ## We deliberately exclude the outcome of interest
     mice::futuremice(m = imputations, method="pmm", n.core=cores) |>
-    mice::complete(action = "all", include = FALSE)
+    mice::complete(action = "long", include = TRUE)
+mice_pmm <- dplyr::mutate(mice_pmm, .imp = factor(.imp, levels = c(0,1,2,3,4), labels = c("Original", "1", "2", "3", "4")))
+
 ## CART (Classification And Regression Trees)
 mice_cart <- df_complete |>
     dplyr::select(-final_pathology) |>    ## We deliberately exclude the outcome of interest
     mice::futuremice(m = imputations, method="cart", n.core=cores) |>
-    mice::complete(action = "all", include = FALSE)
+    mice::complete(action = "long", include = TRUE)
+mice_cart <- dplyr::mutate(mice_cart, .imp = factor(.imp, levels = c(0,1,2,3,4), labels = c("Original", "1", "2", "3", "4")))
+
 ## Random Forest
 mice_rf <- df_complete |>
     dplyr::select(-final_pathology) |>    ## We deliberately exclude the outcome of interest
     mice::futuremice(m = imputations, method="rf", n.core=cores) |>
-    mice::complete(action = "all", include = FALSE)
+    mice::complete(action = "long", include = TRUE)
+mice_rf <- dplyr::mutate(mice_rf, .imp = factor(.imp, levels = c(0,1,2,3,4), labels = c("Original", "1", "2", "3", "4")))
+
 
 ## Define two functions for plotting
 #' Plot histograms of a continuous variable in original and imputed data sets.
 #'
 #' @param original data.frame|tibble The original data frame.
 #' @param pmm mice MICE object from Predictive Mean Modelling.
-#' @param cart mice MICE object from Predictive Mean Modelling.
-#' @param imputation mice MICE object from Predictive Mean Modelling.
+#' @param cart mice MICE object from CART.
+#' @param rf mice MICE object from Random Forest.
 #' @param to_plot str Variable to plot, should be a continuous variable for histograms.
 #' @param imputation int The immputation set to plot.
+#' @param format str The "action" option used in 'mice_complete()', either "all" or "long" are supported.
+#' @param colours list A list of length four of colours to use when plotting.
 plot_imputed_hist <- function(original, pmm, cart, rf,
                               to_plot,
                               imputation = 1,
+                              format = "long",
                               colours = c("#ad1538", "#15ad4f", "#1543ad", "#ad8415")) {
-    df <- data.frame(original = original[to_plot],
+    if (format == "all") {
+        df <- data.frame(original = original[to_plot],
                      pmm = pmm[[imputation]][to_plot],
                      cart = cart[[imputation]][to_plot],
                      rf = rf[[imputation]][to_plot])
+    }
+    if (format == "long") {
+        df <- data.frame(original = original[to_plot],
+                     pmm = pmm |> dplyr::filter(.imp == imputation) |> dplyr::select(to_plot),
+                     cart = cart |> dplyr::filter(.imp == imputation) |> dplyr::select(to_plot),
+                     rf = rf |> dplyr::filter(.imp == imputation) |> dplyr::select(to_plot))
+    }
     colnames(df) <- c("original", "pmm", "cart", "rf")
     hist_obs <- df |>
         ggplot2::ggplot(aes(original)) +
@@ -78,18 +95,29 @@ plot_imputed_hist <- function(original, pmm, cart, rf,
 #'
 #' @param original data.frame|tibble The original data frame.
 #' @param pmm mice MICE object from Predictive Mean Modelling.
-#' @param cart mice MICE object from Predictive Mean Modelling.
-#' @param imputation mice MICE object from Predictive Mean Modelling.
+#' @param cart mice MICE object from CART.
+#' @param rf mice MICE object from Random Forest.
 #' @param to_plot str Variable to plot, should be a continuous variable for histograms.
 #' @param imputation int The immputation set to plot.
+#' @param format str The "action" option used in 'mice_complete()', either "all" or "long" are supported.
+#' @param colours list A list of length four of colours to use when plotting.
 plot_imputed_cat <- function(original, pmm, cart, rf,
                              to_plot,
                              imputation = 1,
+                             format = "long",
                              colours = c("#ad1538", "#15ad4f", "#1543ad", "#ad8415")) {
-    df <- data.frame(original = original[to_plot],
+    if (format == "all") {
+        df <- data.frame(original = original[to_plot],
                      pmm = pmm[[imputation]][to_plot],
                      cart = cart[[imputation]][to_plot],
                      rf = rf[[imputation]][to_plot])
+    }
+    if (format == "long") {
+        df <- data.frame(original = original[to_plot],
+                     pmm = pmm |> dplyr::filter(.imp == imputation) |> dplyr::select(to_plot),
+                     cart = cart |> dplyr::filter(.imp == imputation) |> dplyr::select(to_plot),
+                     rf = rf |> dplyr::filter(.imp == imputation) |> dplyr::select(to_plot))
+    }
     colnames(df) <- c("original", "pmm", "cart", "rf")
     bar_obs <- df |>
         dplyr::filter(!is.na(original)) |>
@@ -135,6 +163,7 @@ plot_imputed_hist(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "albumin",
+                  format = "long",
                   imputation = 1)
 ```
 
@@ -152,6 +181,7 @@ plot_imputed_hist(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "monocyte",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -170,6 +200,7 @@ plot_imputed_hist(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "lymphocytes",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -188,6 +219,7 @@ plot_imputed_hist(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "tsh_value",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -206,6 +238,7 @@ plot_imputed_hist(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "size_nodule_mm",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -229,6 +262,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "incidental_nodule",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -247,6 +281,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "palpable_nodule",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -265,6 +300,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "rapid_enlargement",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -283,6 +319,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "compressive_symptoms",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -301,6 +338,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "hypertension",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -319,6 +357,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "vocal_cord_paresis",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -337,6 +376,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "graves_disease",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -355,6 +395,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "hashimotos_thyroiditis",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -373,6 +414,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "family_history_thyroid_cancer",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -391,6 +433,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "exposure_radiation",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -409,6 +452,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "solitary_nodule",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -427,6 +471,7 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "bta_u_classification",
+                  format = "long",
                   imputation = 1)
 
 ```
@@ -445,19 +490,54 @@ plot_imputed_cat(original = df_complete,
                   cart = mice_cart,
                   rf = mice_rf,
                   to_plot = "cervical_lymphadenopathy",
+                  format = "long",
                   imputation = 1)
 
 ```
 
 
-**TODO** - In addition to the above graphs you may want to construct summary tables for each of the imputed datasets
-done by each method. These are stored in `mice_pmm`, `mice_cart` and `mice_rf`, each of which is a list and you can
-access each dataframe by indexing the list (indexing starts with `1` in R unlike most other programming languages). Thus
-to get at the 3 dataset that was imputed with `mice_cart` you would use `mice_cart[[3]]`. The extracted datasets can be
-combined with the `gtsummary::table_summary()` (or you could modify the
-[`action`](https://amices.org/mice/reference/complete.mids.html#details) option to `mice::complete()` which controls how
-the results of imputation are handled as this can be set to return `long` format data which can then be summarised more
-easily) .
+
+:::
+
+
+::: {.panel-tabset}
+
+## PMM
+
+```{r}
+#| label: tbl-imputation-summary-pmm
+#| tbl-caption: Summary of data imputed via PMM.
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+mice_pmm |> gtsummary::tbl_summary(by=".imp")
+```
+
+## CART
+
+```{r}
+#| label: tbl-imputation-summary-cart
+#| tbl-caption: Summary of data imputed via CART.
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+mice_cart |> gtsummary::tbl_summary(by=".imp")
+
+```
+
+## RF
+
+```{r}
+#| label: tbl-imputation-summary-rf
+#| tbl-caption: Summary of data imputed via Random Forest.
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+mice_rf |> gtsummary::tbl_summary(by=".imp")
+```
 
 :::
 

--- a/sections/_lasso.qmd
+++ b/sections/_lasso.qmd
@@ -77,7 +77,7 @@ Tidymodels framework the model `fit` is wrapped up inside (hence the above artic
 
 
 ``` {r}
- #| label: lasso-save
+#| label: lasso-save
 #| purl: true
 #| eval: true
 #| echo: true


### PR DESCRIPTION
There is one instance where `graves_disease` is recorded as `no` rather than `No`, that is now corrected.

Imputation is tweaked and the suggested table that summarises the data under each method and imputation is now included. In doing so I've removed some of the duplicated tables that were starting to grow in favour of these imputed tables.

Code is left in place as it may be desirable to use some of them in say an Appendix.

**NB** the `r/shf_thy_nod.R` script has been modified you will have to re-run this to pick up the changes and update the `data/r/clean.rds` file.