### PR TITLE
Using purrr on imputed datasets

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -104,47 +104,8 @@ r_scripts <- paste(base_dir, "r", sep = "/")
 ## saved to `data/r/clean.rds` can be loaded by commenting out the line above and uncommenting the line below.
 df <- readRDS(paste(r_dir, "clean.rds", sep="/"))
 
-
-## @ns-rse 2024-06-18:
-## We want this table to match the model, therefore rather than repeat ourselves we move the subsetting to give us
-## df_complete to here and assign to df_complete. This is then passed into gtsummary::tbl_summary() and is available for
-## the next code chunk.
-##
-## This is the point at which you should subset your data for those who have data available for the variables of
-## interest. The variables here should include the outcome `final_pathology` and the predictor variables that are set in
-## the code chunk `recipe`. May want to move this to another earlier in the processing so that the number of rows can be
-## counted and reported.
-df_complete <- df |>
-  dplyr::select(
-    age_at_scan,
-    gender,
-    ethnicity,
-    incidental_nodule,
-    palpable_nodule,
-    rapid_enlargement,
-    compressive_symptoms,
-    hypertension,
-    vocal_cord_paresis,
-    graves_disease,
-    hashimotos_thyroiditis,
-    family_history_thyroid_cancer,
-    exposure_radiation,
-    albumin,
-    tsh_value,
-    lymphocytes,
-    monocyte,
-    bta_u_classification,
-    solitary_nodule,
-    size_nodule_mm,
-    cervical_lymphadenopathy,
-    thy_classification,
-    final_pathology) |>
-## @ns-rse 2024-06-14 :
-## I would consider removing this dplyr::filter() and instead using the recipes::step_filter_missing() as is now in
-## place below
-## dplyr::filter(if_any(everything(), is.na))
-## Instead I think it might be useful to remove individuals who do not have a value for final_pathology here
-  dplyr::filter(!is.na(final_pathology))
+## Load df_complete which has observations with missing final_pathology removed and has subset the variables.
+df_complete <- readRDS(paste(r_dir, "df_complete.rds", sep))
 
 ```
 

--- a/index.qmd
+++ b/index.qmd
@@ -103,9 +103,9 @@ r_scripts <- paste(base_dir, "r", sep = "/")
 ## If nothing has changed in the underlying data or the cleaning/tidying process then the last version of the data,
 ## saved to `data/r/clean.rds` can be loaded by commenting out the line above and uncommenting the line below.
 df <- readRDS(paste(r_dir, "clean.rds", sep="/"))
-
+g
 ## Load df_complete which has observations with missing final_pathology removed and has subset the variables.
-df_complete <- readRDS(paste(r_dir, "df_complete.rds", sep))
+df_complete <- readRDS(paste(r_dir, "df_complete.rds", sep="/"))
 
 ```
 

--- a/index.qmd
+++ b/index.qmd
@@ -61,22 +61,23 @@ execute:
 #| warning: false
 
 ## Libraries for data manipulation, plotting and tabulating (sorted alphabetically)
-library(dplyr)
-library(ggplot2)
-library(ggdark)
-library(gtsummary)
 library(Hmisc)
+library(dplyr)
+library(ggdark)
+library(ggplot2)
+library(gtsummary)
 library(knitr)
 library(mice)
+library(naniar)
 library(readr)
 library(rmarkdown)
 library(visdat)
-library(naniar)
-
 ## Libraries for Tidymodelling
 library(dials)
+library(furrr)
 library(kernlab)
 library(knitr)
+library(purrr)
 library(tidymodels)
 library(tidyverse)
 library(vip)
@@ -353,28 +354,32 @@ A total of `r df_complete |> nrow()` patients had complete data for the selected
 Because of the volume of missing data which if a saturated model were used would include only ~350 people with complete
 data across all co-variates imputed datasets were analysed instead.
 
+{{< include sections/_modelling.qmd >}}
+
 #### Logistic Regression
 
-{{< include sections/_logistic.qmd >}}
+<!-- {{< include sections/_logistic.qmd >}} -->
 
 #### LASSO
 
-{{< include sections/_lasso.qmd >}}
+<!-- {{< include sections/_lasso.qmd >}} -->
+
+{{< include sections/_lasso_imputed.qmd >}}
 
 #### Elastic Net
 
-{{< include sections/_elastic.qmd >}}
+<!-- {{< include sections/_elastic.qmd >}} -->
 
 #### Random Forest
 
-{{< include sections/_rforest.qmd >}}
+<!-- {{< include sections/_rforest.qmd >}} -->
 
 #### Gradient Boosting
 
-{{< include sections/_gradientboost.qmd >}}
+<!-- {{< include sections/_gradientboost.qmd >}} -->
 
 
-#### SVM
+<!-- #### SVM -->
 
 <!-- {{< include sections/_svm.qmd >}} -->
 
@@ -406,7 +411,7 @@ The take-away message is....these things are hard!
 ```{r}
 #| label: tbl-variables
 #| purl: true
-#| eval: true
+#| eval: false
 #| echo: false
 #| warning: false
 #| tbl-caption: "Description of variables in the Sheffield Thyroid dataset."

--- a/index.qmd
+++ b/index.qmd
@@ -103,7 +103,7 @@ r_scripts <- paste(base_dir, "r", sep = "/")
 ## If nothing has changed in the underlying data or the cleaning/tidying process then the last version of the data,
 ## saved to `data/r/clean.rds` can be loaded by commenting out the line above and uncommenting the line below.
 df <- readRDS(paste(r_dir, "clean.rds", sep="/"))
-g
+
 ## Load df_complete which has observations with missing final_pathology removed and has subset the variables.
 df_complete <- readRDS(paste(r_dir, "df_complete.rds", sep="/"))
 

--- a/r/functions.R
+++ b/r/functions.R
@@ -1,0 +1,320 @@
+#' Function for fitting different models to a dataset
+#'
+#' For this work we want to fit models to datasets that have been imputed using the MICE package
+#'
+#' @df data.frame Dataframe to be analysed
+#' @imputed logical Whether the data frame is an imputed data set
+#' @prop float Proportion to split the data by for training/testing. Default is 0.75
+#' @v int Number of folds for cross-validation. Default is 10.
+#' @repeats int Number of repeats for cross-validation. Default is 10.
+#' @missing_threshold float Proportion of missing data allowed, used in 'recipes::step_filter_missing()'. Default is 0
+#' @outcome Outcome variable
+#' @continuous vector Vector of continuous predictor variables.
+#' @categorical vector Vector of categorical/nominal predictor variables.
+#' @model_type str The type of model to fit, options are 'elastic', 'lasso' 'xgboost', 'svm'
+#' @mixture float Mixture to use in Elastic Net ('elastic') models. '0' gives Ridge Regression, '1' LASSO. Default
+#' '0.5'.
+#' @vi_method str The Variable Importance method used to extract importance. Default is 'shap' other options are
+#' 'model', 'firm' and 'permute'. See '?vip::vi' for more information.
+#' @vi_sort bool Whether to sort the Variable Importance output. See '?vip::vi' for more information. Default FALSE
+#' @vi_scale bool Whether to scale the Variable Importance output. See '?vip::vi' for more information. Default FALSE
+#' @vi_rank bool Whether to rank the Variable Importance output. See '?vip::vi' for more information. Default TRUE
+#' ... Hyperparameters to pass to the selected model_type
+#'
+#' @seealso [mice, vip]
+#' @export
+#' @examples
+model_fitting <- function(df,
+                          imputed = TRUE,
+                          prop = 0.75,
+                          v = 10,
+                          repeats = 10,
+                          missing_threshold = 0.0,
+                          outcome = "final_pathology",
+                          continuous = c("albumin", "tsh_value", "lymphocytes", "monocyte", "size_nodule_mm"),
+                          categorical = c(
+                              "ethnicity",
+                              "incidental_nodule",
+                              "palpable_nodule",
+                              "rapid_enlargement",
+                              "compressive_symptoms",
+                              "hypertension",
+                              "vocal_cord_paresis",
+                              "graves_disease",
+                              "hashimotos_thyroiditis",
+                              "family_history_thyroid_cancer",
+                              "exposure_radiation",
+                              "bta_u_classification",
+                              "solitary_nodule",
+                              "cervical_lymphadenopathy",
+                              "thy_classification"
+                          ),
+                          model_type = "lasso",
+                          mixture = 0.5,
+                          vi_method = "model",  ## Ideally want to use 'snap' to make comparisons
+                          vi_sort = FALSE,
+                          vi_scale = FALSE,
+                          vi_rank = TRUE,
+                          ...) {
+    ## If this is an imputed dataset we need to remove -.imp and -.id variables
+    if (imputed) {
+        df <- df |>
+            dplyr::select(-.imp, -.id)
+    }
+    ## Select the variables of interest
+    df <- df |>
+        dplyr::select({{ outcome }}, {{ continuous }}, {{ categorical }})
+    ## Split the data into training and test data
+    split <- df |>
+        rsample::initial_split(prop = prop)
+    train <- rsample::training(split)
+    test <- rsample::testing(split)
+    ## Create k-fold validation on training data
+    cv_folds <- rsample::vfold_cv(train, v = v, repeats = repeats)
+    ## Setup a recipe, the steps involved removing individuals with missing data
+    ## ns-rse 2024-09-20 : Ideally we shouldn't have final_pathology hard coded here but the "embrace" method of
+    ## indirection (see vignette("programmin")) doesn't seem to work with recipes. Online example of creating own recipe
+    ## step function (https://www.tidymodels.org/learn/develop/recipes/index.html#create-the-function) uses the older
+    ## enquos() method
+    thyroid_recipe <- recipes::recipe(final_pathology ~ ., data = train) |>
+        recipes::step_filter_missing(recipes::all_predictors(), threshold = missing_threshold) |>
+        recipes::step_normalize(recipes::all_numeric_predictors()) |>
+        recipes::step_dummy(recipes::all_nominal_predictors())
+    ## Add recipe to a workrlow
+    thyroid_workflow <- workflows::workflow() |>
+        workflows::add_recipe(thyroid_recipe)
+    ## Conditionally fit the model based on the requested method, this involves setting up a parsnip model specification
+    ## and then tune it via tune::tune_grid()
+    ## @ns-rse 2024-09-20 : Refactor and abstract out common components have parsnip::() and grid_regular() set in each
+    ## conditional section and a final tune::tune_grid() that takes whatever these values are set to.
+    if (model_type == "elastic") {
+        message(paste0("Fitting Elastic Net (mixture : ", mixture, ")", sep=""))
+        parsnip_tune <- parsnip::logistic_reg(
+            penalty = hardhat::tune(),
+            mixture = mixture
+        ) |>
+            parsnip::set_mode("classification") |>
+            parsnip::set_engine("glmnet")
+        dials_grid <- dials::grid_regular(dials::penalty(), levels = 50)
+        ## grid <- tune::tune_grid(
+        ##     object = workflows::add_model(thyroid_workflow, parsnip_tune),
+        ##     resamples = cv_folds,
+        ##     grid = dials_grid
+        ## )
+    } else if (model_type == "forest") {
+        message("Fitting Random Forest")
+        ## @ns-rse 2024-09-20 : For flexibility we could set things up to specify different engines here
+        parsnip_tune <- parsnip::rand_forest(
+            mtry = hardhat::tune(),
+            trees = 100,
+            min_n = hardhat::tune()
+        ) |>
+            parsnip::set_mode("classification") |>
+            parsnip::set_engine("ranger", importance = "impurity")
+        dials_grid <- dials::grid_regular(
+            dials::mtry(range = c(5, 10)), # smaller ranges will run quicker
+            dials::min_n(range = c(2, 25)),
+            levels = 3
+        )
+        ## grid <- tune::tune_grid(
+        ##     object = workflows::add_model(thyroid_workflow, parsnip_tune),
+        ##     resamples = cv_folds,
+        ##     grid = dials_grid
+        ## )
+    } else if (model_type == "xgboost") {
+        message("Fitting Gradient Boosting")
+        parsnip_tune <- parsnip::boost_tree(
+            mode = "classification",
+            trees = 100,
+            min_n = hardhat::tune(),
+            tree_depth = hardhat::tune(),
+            learn_rate = hardhat::tune(),
+            loss_reduction = hardhat::tune()
+        ) |>
+            parsnip::set_mode("classification") |>
+            parsnip::set_engine("xgboost", objective = "binary:logistic")
+        ## Specify the models tuning parameters using the `dials` package along (https://dials.tidymodels.org/) with the grid
+        ## space. This helps identify the hyperparameters with the lowest prediction error.
+        dials_params <- dials::parameters(
+            dials::min_n(),
+            dials::tree_depth(),
+            dials::learn_rate(),
+            dials::loss_reduction()
+        )
+        dials_grid <- dials::grid_max_entropy(
+            dials_params,
+            size = 10
+        )
+    }
+    ## Not bothering with SVM modelling, there are errors in the calculations during modelling and no methods available
+    ## to extract Variable Importance
+    ## else if (model_type == "svm") {
+    ##     message("Fitting Support Vector Machine")
+    ##     parsnip_tune <- parsnip::svm_rbf(cost = tune()) |>
+    ##       parsnip::set_mode("classification") |>
+    ##       parsnip::set_engine("kernlab")
+    ##     dials_grid <- dials::grid_regular(dials::cost(), levels = 20)
+    ## }
+    ## Set common metrics and control
+    yardstick_metrics <- yardstick::metric_set(yardstick::roc_auc,
+                                               yardstick::accuracy,
+                                               yardstick::ppv)
+    control <- tune::control_grid(verbose = FALSE)
+    ## Tune the model
+    tuned_model <- tune::tune_grid(
+                             workflows::add_model(thyroid_workflow, parsnip_tune),
+                             resamples = cv_folds, ## cv_loo,
+                             grid = dials_grid,
+                             metrics = yardstick_metrics,
+                             control = control
+                         )
+    ## Select the best model based on ROC Area Under the Curve and finalise the workflow by adding the tunde model and
+    ## best metric fit
+    best_metric_fit <- tuned_model |>
+        tune::select_best()
+    final_model <- tune::finalize_workflow(workflows::add_model(thyroid_workflow, spec = parsnip_tune), best_metric_fit)
+    fit <- final_model |>
+        fit(train)
+    ## Extract importance
+    importance <- fit |>
+        hardhat::extract_fit_parsnip() |>
+        vip::vi(method = vi_method,
+                sort = vi_sort,
+                scale = vi_scale,
+                rank = vi_rank)
+    ## Add Sign if not present
+    if (!("Sign" %in% colnames(importance))) {
+        importance <- importance |>
+            dplyr::mutate(Sign = "POS")
+    }
+    ## Plot importance
+    importance_plot <- importance |>
+        ggplot2::ggplot(mapping = aes(x = Importance, y = Variable, fill = Sign)) +
+        ggplot2::geom_col() +
+        ggdark::dark_theme_minimal()
+    ########################################################
+    ## Summarise model on train data set                  ##
+    ########################################################
+    ## Make predictions on train subset
+    train[".pred_class"] <- fit |>
+        predict(train)
+    train[".pred_prob"] <- fit |>
+        predict(train, type="prob")
+    ## ToDo - Remove hard coding of final_pathology from yardstick calls (enquotes?)
+    train_summary_metrics <- train |>
+        yardstick::conf_mat(final_pathology, .pred_class) |>
+        summary()
+    auc <- train |>
+        yardstick::roc_auc(final_pathology, .pred_prob)
+    train_summary_metrics <- rbind(train_summary_metrics, auc)
+    train_roc_curve <- train |>
+        ## ToDo - Remove hard coding of final_pathology
+        yardstick::roc_curve(final_pathology, .pred_prob)
+    train_roc_curve_plot <- train_roc_curve |>
+        ggplot2::ggplot(aes(x = 1 - specificity, y = sensitivity)) +
+        ggplot2::geom_path() +
+        ggplot2::geom_abline(lty = 3) +
+        ggplot2::coord_equal() +
+        ggdark::dark_theme_minimal()
+    ########################################################
+    ## Summarise model on train data set                  ##
+    ########################################################
+    ## Make predictions on test subset
+    test[".pred_class"] <- fit |>
+        predict(test)
+    test[".pred_prob"] <- fit |>
+        predict(test, type="prob")
+    ## ToDo - Remove hard coding of final_pathology from yardstick calls (enquotes?)
+    test_summary_metrics <- test |>
+        yardstick::conf_mat(final_pathology, .pred_class) |>
+        summary()
+    auc <- test |>
+        yardstick::roc_auc(final_pathology, .pred_prob)
+    test_summary_metrics <- rbind(test_summary_metrics, auc)
+    test_roc_curve <- test |>
+        ## ToDo - Remove hard coding of final_pathology
+        yardstick::roc_curve(final_pathology, .pred_prob)
+    test_roc_curve_plot <- test_roc_curve |>
+        ggplot2::ggplot(aes(x = 1 - specificity, y = sensitivity)) +
+        ggplot2::geom_path() +
+        ggplot2::geom_abline(lty = 3) +
+        ggplot2::coord_equal() +
+        ggdark::dark_theme_minimal()
+    ## Combine results into a single list for returning
+    results <- list()
+    results$train <- train
+    results$test <- test
+    results$folds <- cv_folds
+    results$recipe <- recipe
+    results$workflow <- workflow
+    results$parsnip <- parsnip_tune
+    results$grid <- dials_grid
+    results$yardstick <- yardstick_metrics
+    results$control <- control
+    results$best <- best_metric_fit
+    results$final_model <- final_model
+    results$importance <- importance
+    results$importance_plot <- importance_plot
+    if (model_type == "elastic") {
+        results$broom_estimate <- fit |> broom::tidy()
+    }
+    results$fit <- fit
+    results$train_summary_metrics <- train_summary_metrics
+    results$train_roc_curve <- train_roc_curve
+    results$train_roc_curve_plot <- train_roc_curve_plot
+    results$test_summary_metrics <- test_summary_metrics
+    results$test_roc_curve <- test_roc_curve
+    results$test_roc_curve_plot <- test_roc_curve_plot
+    results
+}
+
+
+#' Extract and combine summary statistics from analysis of multiple imputed data sets
+#'
+#' @imputed_models list A list of imputed models from having mapped model_fitting() with purrr() on an imputed data set.
+#' @model_type str The type of model that has been fitted across the imputed datasets
+#'
+tidy_imputed_models <- function(imputed_models, model_type) {
+    results <- list()
+    ## Extract importance
+    importance <- imputed_models |>
+        purrr::map(`[[`, "importance") |>
+        dplyr::bind_rows(.id = "imputation") |>
+        ## tidyr::spread(key = imputation, value = Importance)
+        tidyr::pivot_wider(names_from = imputation, values_from = Importance)
+    if (model_type %in% c("elastic", "xgboost")){
+        importance <- importance |>
+            dplyr::arrange(Variable, Sign)
+    }
+    else {
+        importance <- importance |>
+            dplyr::arrange(Variable)
+    }
+    ## Extract Summary Statistics for test and train
+    test_metrics <- imputed_models |>
+        purrr::map(`[[`, "test_summary_metrics") |>
+        dplyr::bind_rows(.id = "imputation") |>
+        ## dplyr::select(-.estimate) |>
+        ## tidyr::spread(key = imputation, value = .estimator)
+        tidyr::pivot_wider(names_from = imputation, values_from = .estimate)
+    train_metrics <- imputed_models |>
+        purrr::map(`[[`, "train_summary_metrics") |>
+        dplyr::bind_rows(.id = "imputation") |>
+        ## dplyr::select(-.estimate) |>
+        tidyr::spread(key = imputation, value = .estimate)
+    ## Extract ROC curves (NB these are not converted to wide format to simplify plotting)
+    test_roc_metrics <- imputed_models |>
+        purrr::map(`[[`, "test_roc_curve") |>
+        dplyr::bind_rows(.id = "imputation")
+    train_roc_metrics <- imputed_models |>
+        purrr::map(`[[`, "train_roc_curve") |>
+        dplyr::bind_rows(.id = "imputation")
+    ## TODO - Plot test and train ROC curves coloured by imputation
+    ## Add all summaries to results
+    results$importance <- importance
+    results$test_metrics <- test_metrics
+    results$train_metrics <- train_metrics
+    results$test_roc_metrics <- test_roc_metrics
+    results$train_roc_metrics <- train_roc_metrics
+    results
+}

--- a/references.bib
+++ b/references.bib
@@ -1,4 +1,20 @@
 ﻿
+@article{Schomaker2014Mar,
+	author = {Schomaker, Michael and Heumann, Christian},
+	title = {{Model selection and model averaging after multiple imputation}},
+	journal = {Comput. Statist. Data Anal.},
+	volume = {71},
+	pages = {758--770},
+	year = {2014},
+	month = mar,
+	issn = {0167-9473},
+	publisher = {North-Holland},
+	doi = {10.1016/j.csda.2013.02.017},
+	keywords = {Akaike{'}s information criterion, Bootstrap, Frequentist model averaging, Linear regression, Missing data, Survival analysis},
+	abstract = {{Model selection and model averaging are two important techniques to obtain practical and useful models in applied research. However, it is now well-known that many complex issues arise, especially in the context of model selection, when the stochastic nature of the selection process is ignored and estimates, standard errors, and confidence intervals are calculated as if the selected model was known a priori. While model averaging aims to incorporate the uncertainty associated with the model selection process by combining estimates over a set of models, there is still some debate over appropriate interpretation and confidence interval construction. These problems become even more complex in the presence of missing data and it is currently not entirely clear how to proceed. To deal with such situations, a framework for model selection and model averaging in the context of missing data is proposed. The focus lies on multiple imputation as a strategy to deal with the missingness: a consequent combination with model averaging aims to incorporate both the uncertainty associated with the model selection and with the imputation process. Furthermore, the performance of bootstrapping as a flexible extension to our framework is evaluated. Monte Carlo simulations are used to reveal the nature of the proposed estimators in the context of the linear regression model. The practical implications of our approach are illustrated by means of a recent survival study on sputum culture conversion in pulmonary tuberculosis.}}
+}
+
+
 @book{Efron2016Jul,
 	author = {Efron, Bradley and Hastie, Trevor},
 	title = {{Computer Age Statistical Inference: Algorithms, Evidence, and Data Science}},

--- a/sections/_elastic.qmd
+++ b/sections/_elastic.qmd
@@ -14,10 +14,10 @@ tune_spec_elastic <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 
   parsnip::set_engine("glmnet")
 
 ## Tune the Elastic Net parameters via cross-validation
-lasso_grid <- tune::tune_grid(
+elastic_grid <- tune::tune_grid(
   object = workflows::add_model(thyroid_workflow, tune_spec_elastic),
   resamples = cv_folds,
-  grid = dials::grid_regular(penalty(), levels = 50)
+  grid = dials::grid_regular(dials::penalty(), levels = 50)
 )
 ```
 
@@ -32,7 +32,7 @@ lasso_grid <- tune::tune_grid(
 ##
 ## This shows how the evaluation metrics change over time with each iteration of the Lasso (we know we are running a
 ## Elastic Net because when we setup tune_spec_elastic the mixture = 1 when we define parsnip::logistic_reg()
-tune::autoplot(lasso_grid)
+tune::autoplot(elastic_grid)
 ```
 
 
@@ -44,7 +44,7 @@ tune::autoplot(lasso_grid)
 #| echo: false
 #| output: true
 ## K-fold best fit for Elastic Net
-lasso_kfold_roc_auc <- lasso_grid |>
+elastic_kfold_roc_auc <- elastic_grid |>
   tune::select_best(metric = "roc_auc")
 ```
 
@@ -58,7 +58,7 @@ lasso_kfold_roc_auc <- lasso_grid |>
 ## Fit the final Elastic Net model
 final_elastic_kfold <- tune::finalize_workflow(
   workflows::add_model(thyroid_workflow, tune_spec_elastic),
-  lasso_kfold_roc_auc
+  elastic_kfold_roc_auc
 )
 ```
 
@@ -72,7 +72,7 @@ final_elastic_kfold <- tune::finalize_workflow(
 final_elastic_kfold |>
   fit(train) |>
   hardhat::extract_fit_parsnip() |>
-  vip::vi(lambda = lasso_kfold_roc_auc$penalty) |>
+  vip::vi(lambda = elastic_kfold_roc_auc$penalty) |>
   dplyr::mutate(
     Importance = abs(Importance),
     Variable = fct_reorder(Variable, Importance)
@@ -97,7 +97,7 @@ Tidymodels framework the model `fit` is wrapped up inside (hence the above artic
 #| eval: true
 #| echo: false
 #| output: false
-save(tune_spec_elastic, lasso_grid, final_elastic_kfold, lasso_kfold_roc_auc,
-  file = "data/r/lasso.RData"
+save(tune_spec_elastic, _grid, final_elastic_kfold, elastic_kfold_roc_auc,
+  file = "data/r/elastic.RData"
 )
 ```

--- a/sections/_gradientboost.qmd
+++ b/sections/_gradientboost.qmd
@@ -10,20 +10,20 @@
 model_xgboost <- parsnip::boost_tree(
     mode = "classification",
     trees = 100,
-    min_n = tune(),
-    tree_depth = tune(),
-    learn_rate = tune(),
-    loss_reduction = tune()
+    min_n = hardhat::tune(),
+    tree_depth = hardhat::tune(),
+    learn_rate = hardhat::tune(),
+    loss_reduction = hardhat::tune()
 ) |>
   set_engine("xgboost", objective = "binary:logistic")
 
 ## Specify the models tuning parameters using the `dials` package along (https://dials.tidymodels.org/) with the grid
 ## space. This helps identify the hyperparameters with the lowest prediction error.
 xgboost_params <- dials::parameters(
-    min_n(),
-    tree_depth(),
-    learn_rate(),
-    loss_reduction()
+    dials::min_n(),
+    dials::tree_depth(),
+    dials::learn_rate(),
+    dials::loss_reduction()
 )
 xgboost_grid <- dials::grid_max_entropy(
     xgboost_params,

--- a/sections/_imputation.qmd
+++ b/sections/_imputation.qmd
@@ -111,6 +111,19 @@ impute_data <- function(df = df_complete,
                                                    ggplot2::aes(x = .data[[var]],
                                                                 fill = .imp)) +
                                         ggplot2::geom_bar(position = "dodge")
+        ## Above bar chart is often hard to read, instead make a custom bar chart of the propotion in each category by
+        ## each imputation
+        results$bar_chart_prop[[var]] <- results$imputed |>
+                   dplyr::group_by(.imp, .data[[var]]) |>
+                   dplyr::summarize(count = n()) |>
+                   dplyr::group_by(.imp) |>
+                   dplyr::mutate(prop = count / sum(count)) |>
+                   ggplot2::ggplot(aes(x = .data[[var]],
+                                       y = prop,
+                                       fill = .imp)) +
+                   ggplot2::geom_bar(stat = "identity", position = "dodge") +
+                   ggplot2::theme(legend.position = "none")
+
     }
     results
 }
@@ -134,47 +147,9 @@ mice_rf <- impute_data(method = "rf",
 
 ```
 
-The convergence of the imputation methods are shown in figues @fig-mice-convergence-pmm, @fig-mice-convergence-cart, and
-@fig-mice-convergence-rf.
-
-::: {.panel-tabset}
-
-```{r}
-#| label: fig-mice-convergence-pmm
-#| purl: true
-#| eval: true
-#| echo: false
-#| output: true
-#| out-width: "80%"
-mice_pmm$trace
-
-```
-
-```{r}
-#| label: fig-mice-convergence-cart
-#| purl: true
-#| eval: true
-#| echo: false
-#| output: true
-#| out-width: "80%"
-
-mice_cart$trace
-
-```
-
-```{r}
-#| label: fig-mice-convergence-rf
-#| purl: true
-#| eval: true
-#| echo: false
-#| output: true
-#| out-width: "80%"
-mice_rf$trace
-
-```
-
-:::
-
+The distribution of observed (blue) and imputed values for continous variables are shown in the Tab set immediately
+below and across all variables the imputed distrubtions follow closely that of the observed indicating that the
+imputation methods have worked well for all three methods tested.
 
 ::: {.panel-tabset}
 
@@ -190,6 +165,7 @@ mice_rf$trace
 cowplot::plot_grid(mice_pmm$histogram$albumin,
                    mice_cart$histogram$albumin,
                    mice_rf$histogram$albumin,
+                   labels = c("PMM", "Cart", "Random Forest"),
                    nrow = 1,
                    ncol = 3)
 ```
@@ -206,6 +182,7 @@ cowplot::plot_grid(mice_pmm$histogram$albumin,
 cowplot::plot_grid(mice_pmm$histogram$monocyte,
                    mice_cart$histogram$monocyte,
                    mice_rf$histogram$monocyte,
+                   labels = c("PMM", "Cart", "Random Forest"),
                    nrow = 1,
                    ncol = 3)
 
@@ -223,6 +200,7 @@ cowplot::plot_grid(mice_pmm$histogram$monocyte,
 cowplot::plot_grid(mice_pmm$histogram$lymphocytes,
                    mice_cart$histogram$lymphocytes,
                    mice_rf$histogram$lymphocytes,
+                   labels = c("PMM", "Cart", "Random Forest"),
                    nrow = 1,
                    ncol = 3)
 
@@ -240,6 +218,7 @@ cowplot::plot_grid(mice_pmm$histogram$lymphocytes,
 cowplot::plot_grid(mice_pmm$histogram$tsh_value,
                    mice_cart$histogram$tsh_value,
                    mice_rf$histogram$tsh_value,
+                   labels = c("PMM", "Cart", "Random Forest"),
                    nrow = 1,
                    ncol = 3)
 
@@ -257,12 +236,18 @@ cowplot::plot_grid(mice_pmm$histogram$tsh_value,
 cowplot::plot_grid(mice_pmm$histogram$size_nodule_mm,
                    mice_cart$histogram$size_nodule_mm,
                    mice_rf$histogram$size_nodule_mm,
+                   labels = c("PMM", "Cart", "Random Forest"),
                    nrow = 1,
                    ncol = 3)
 
 ```
 
 :::
+
+Similarly for the discrete variables the distribution of proportions in the original and each imputed dataset are shown
+below. The observed (in pink/peach) always have slightly lower proportions of the observed values because of the
+presence of missing (evidences by only one group being present in the `NA` column) but as with the continuous variables
+across all imputation methods the proportions are roughly as expected again indicating that imputation has worked well.
 
 **TODO** - Extract the legends from individual plots and add them to the end of each row, see the [cowplot shared
 legends article](https://wilkelab.org/cowplot/articles/shared_legends.html) for pointers on how to do this. Should
@@ -279,13 +264,17 @@ ideally also get the `fill` colours to align with those used by `ggmice`.
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$incidental_nodule + theme(legend.position = "None"),
-                   mice_cart$scatter$incidental_nodule + theme(legend.position = "None"),
-                   mice_rf$scatter$incidental_nodule + theme(legend.position = "None"),
-                   mice_pmm$bar_chart$incidental_nodule + theme(legend.position = "None"),
-                   mice_cart$bar_chart$incidental_nodule + theme(legend.position = "None"),
-                   mice_rf$bar_chart$incidental_nodule + theme(legend.position = "None"),
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$incidental_nodule + theme(legend.position = "None"),
+                   ## mice_cart$scatter$incidental_nodule + theme(legend.position = "None"),
+                   ## mice_rf$scatter$incidental_nodule + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$incidental_nodule + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$incidental_nodule + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$incidental_nodule + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$incidental_nodule + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$incidental_nodule + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$incidental_nodule + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -299,13 +288,17 @@ cowplot::plot_grid(mice_pmm$scatter$incidental_nodule + theme(legend.position = 
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$palpable_nodule,
-                   mice_cart$scatter$palpable_nodule,
-                   mice_rf$scatter$palpable_nodule,
-                   mice_pmm$bar_chart$palpable_nodule,
-                   mice_cart$bar_chart$palpable_nodule,
-                   mice_rf$bar_chart$palpable_nodule,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$palpable_nodule + theme(legend.position = "None"),
+                   ## mice_cart$scatter$palpable_nodule + theme(legend.position = "None"),
+                   ## mice_rf$scatter$palpable_nodule + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$palpable_nodule + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$palpable_nodule + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$palpable_nodule + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$palpable_nodule + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$palpable_nodule + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$palpable_nodule + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -319,13 +312,17 @@ cowplot::plot_grid(mice_pmm$scatter$palpable_nodule,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$rapid_enlargement,
-                   mice_cart$scatter$rapid_enlargement,
-                   mice_rf$scatter$rapid_enlargement,
-                   mice_pmm$bar_chart$rapid_enlargement,
-                   mice_cart$bar_chart$rapid_enlargement,
-                   mice_rf$bar_chart$rapid_enlargement,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$rapid_enlargement + theme(legend.position = "None"),
+                   ## mice_cart$scatter$rapid_enlargement + theme(legend.position = "None"),
+                   ## mice_rf$scatter$rapid_enlargement + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$rapid_enlargement + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$rapid_enlargement + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$rapid_enlargement + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$rapid_enlargement + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$rapid_enlargement + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$rapid_enlargement + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -339,13 +336,17 @@ cowplot::plot_grid(mice_pmm$scatter$rapid_enlargement,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$compressive_symptoms,
-                   mice_cart$scatter$compressive_symptoms,
-                   mice_rf$scatter$compressive_symptoms,
-                   mice_pmm$bar_chart$compressive_symptoms,
-                   mice_cart$bar_chart$compressive_symptoms,
-                   mice_rf$bar_chart$compressive_symptoms,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$compressive_symptoms + theme(legend.position = "None"),
+                   ## mice_cart$scatter$compressive_symptoms + theme(legend.position = "None"),
+                   ## mice_rf$scatter$compressive_symptoms + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$compressive_symptoms + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$compressive_symptoms + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$compressive_symptoms + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$compressive_symptoms + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$compressive_symptoms + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$compressive_symptoms + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -359,13 +360,17 @@ cowplot::plot_grid(mice_pmm$scatter$compressive_symptoms,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$hypertension,
-                   mice_cart$scatter$hypertension,
-                   mice_rf$scatter$hypertension,
-                   mice_pmm$bar_chart$hypertension,
-                   mice_cart$bar_chart$hypertension,
-                   mice_rf$bar_chart$hypertension,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$hypertension + theme(legend.position = "None"),
+                   ## mice_cart$scatter$hypertension + theme(legend.position = "None"),
+                   ## mice_rf$scatter$hypertension + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$hypertension + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$hypertension + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$hypertension + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$hypertension + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$hypertension + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$hypertension + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -379,13 +384,17 @@ cowplot::plot_grid(mice_pmm$scatter$hypertension,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$vocal_cord_paresis,
-                   mice_cart$scatter$vocal_cord_paresis,
-                   mice_rf$scatter$vocal_cord_paresis,
-                   mice_pmm$bar_chart$vocal_cord_paresis,
-                   mice_cart$bar_chart$vocal_cord_paresis,
-                   mice_rf$bar_chart$vocal_cord_paresis,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$vocal_cord_paresis + theme(legend.position = "None"),
+                   ## mice_cart$scatter$vocal_cord_paresis + theme(legend.position = "None"),
+                   ## mice_rf$scatter$vocal_cord_paresis + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$vocal_cord_paresis + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$vocal_cord_paresis + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$vocal_cord_paresis + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$vocal_cord_paresis + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$vocal_cord_paresis + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$vocal_cord_paresis + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -399,13 +408,17 @@ cowplot::plot_grid(mice_pmm$scatter$vocal_cord_paresis,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$graves_disease,
-                   mice_cart$scatter$graves_disease,
-                   mice_rf$scatter$graves_disease,
-                   mice_pmm$bar_chart$graves_disease,
-                   mice_cart$bar_chart$graves_disease,
-                   mice_rf$bar_chart$graves_disease,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$graves_disease + theme(legend.position = "None"),
+                   ## mice_cart$scatter$graves_disease + theme(legend.position = "None"),
+                   ## mice_rf$scatter$graves_disease + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$graves_disease + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$graves_disease + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$graves_disease + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$graves_disease + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$graves_disease + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$graves_disease + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -419,13 +432,17 @@ cowplot::plot_grid(mice_pmm$scatter$graves_disease,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$hashimotos_thyroiditis,
-                   mice_cart$scatter$hashimotos_thyroiditis,
-                   mice_rf$scatter$hashimotos_thyroiditis,
-                   mice_pmm$bar_chart$hashimotos_thyroiditis,
-                   mice_cart$bar_chart$hashimotos_thyroiditis,
-                   mice_rf$bar_chart$hashimotos_thyroiditis,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$hashimotos_thyroiditis + theme(legend.position = "None"),
+                   ## mice_cart$scatter$hashimotos_thyroiditis + theme(legend.position = "None"),
+                   ## mice_rf$scatter$hashimotos_thyroiditis + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$hashimotos_thyroiditis + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$hashimotos_thyroiditis + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$hashimotos_thyroiditis + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$hashimotos_thyroiditis + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$hashimotos_thyroiditis + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$hashimotos_thyroiditis + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -439,13 +456,17 @@ cowplot::plot_grid(mice_pmm$scatter$hashimotos_thyroiditis,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$family_history,
-                   mice_cart$scatter$family_history,
-                   mice_rf$scatter$family_history,
-                   mice_pmm$bar_chart$family_history,
-                   mice_cart$bar_chart$family_history,
-                   mice_rf$bar_chart$family_history,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$family_history + theme(legend.position = "None"),
+                   ## mice_cart$scatter$family_history + theme(legend.position = "None"),
+                   ## mice_rf$scatter$family_history + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$family_history + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$family_history + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$family_history + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$family_history + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$family_history + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$family_history + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -459,13 +480,17 @@ cowplot::plot_grid(mice_pmm$scatter$family_history,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$exposure_radiation,
-                   mice_cart$scatter$exposure_radiation,
-                   mice_rf$scatter$exposure_radiation,
-                   mice_pmm$bar_chart$exposure_radiation,
-                   mice_cart$bar_chart$exposure_radiation,
-                   mice_rf$bar_chart$exposure_radiation,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$exposure_radiation + theme(legend.position = "None"),
+                   ## mice_cart$scatter$exposure_radiation + theme(legend.position = "None"),
+                   ## mice_rf$scatter$exposure_radiation + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$exposure_radiation + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$exposure_radiation + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$exposure_radiation + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$exposure_radiation + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$exposure_radiation + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$exposure_radiation + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -479,13 +504,17 @@ cowplot::plot_grid(mice_pmm$scatter$exposure_radiation,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$solitary_nodule,
-                   mice_cart$scatter$solitary_nodule,
-                   mice_rf$scatter$solitary_nodule,
-                   mice_pmm$bar_chart$solitary_nodule,
-                   mice_cart$bar_chart$solitary_nodule,
-                   mice_rf$bar_chart$solitary_nodule,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$solitary_nodule + theme(legend.position = "None"),
+                   ## mice_cart$scatter$solitary_nodule + theme(legend.position = "None"),
+                   ## mice_rf$scatter$solitary_nodule + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$solitary_nodule + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$solitary_nodule + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$solitary_nodule + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$solitary_nodule + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$solitary_nodule + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$solitary_nodule + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -499,13 +528,17 @@ cowplot::plot_grid(mice_pmm$scatter$solitary_nodule,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$bta_u_classification,
-                   mice_cart$scatter$bta_u_classification,
-                   mice_rf$scatter$bta_u_classification,
-                   mice_pmm$bar_chart$bta_u_classification,
-                   mice_cart$bar_chart$bta_u_classification,
-                   mice_rf$bar_chart$bta_u_classification,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$bta_u_classification + theme(legend.position = "None"),
+                   ## mice_cart$scatter$bta_u_classification + theme(legend.position = "None"),
+                   ## mice_rf$scatter$bta_u_classification + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$bta_u_classification + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$bta_u_classification + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$bta_u_classification + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$bta_u_classification + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$bta_u_classification + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$bta_u_classification + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```
@@ -519,13 +552,17 @@ cowplot::plot_grid(mice_pmm$scatter$bta_u_classification,
 #| echo: false
 #| output: true
 #| out-width: "80%"
-cowplot::plot_grid(mice_pmm$scatter$cervical_lymphadenopathy,
-                   mice_cart$scatter$cervical_lymphadenopathy,
-                   mice_rf$scatter$cervical_lymphadenopathy,
-                   mice_pmm$bar_chart$cervical_lymphadenopathy,
-                   mice_cart$bar_chart$cervical_lymphadenopathy,
-                   mice_rf$bar_chart$cervical_lymphadenopathy,
-                   nrow = 2,
+cowplot::plot_grid(## mice_pmm$scatter$cervical_lymphadenopathy + theme(legend.position = "None"),
+                   ## mice_cart$scatter$cervical_lymphadenopathy + theme(legend.position = "None"),
+                   ## mice_rf$scatter$cervical_lymphadenopathy + theme(legend.position = "None"),
+                   ## mice_pmm$bar_chart$cervical_lymphadenopathy + theme(legend.position = "None"),
+                   ## mice_cart$bar_chart$cervical_lymphadenopathy + theme(legend.position = "None"),
+                   ## mice_rf$bar_chart$cervical_lymphadenopathy + theme(legend.position = "None"),
+                   mice_pmm$bar_chart_prop$cervical_lymphadenopathy + theme(legend.position = "None"),
+                   mice_cart$bar_chart_prop$cervical_lymphadenopathy + theme(legend.position = "None"),
+                   mice_rf$bar_chart_prop$cervical_lymphadenopathy + theme(legend.position = "None"),
+                   labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 1,
                    ncol = 3)
 
 ```

--- a/sections/_imputation.qmd
+++ b/sections/_imputation.qmd
@@ -583,10 +583,11 @@ cowplot::plot_grid(## mice_pmm$scatter$cervical_lymphadenopathy + theme(legend.p
 #| label: tbl-imputation-summary-pmm
 #| tbl-caption: Summary of data imputed via PMM.
 #| purl: true
-#| eval: true
+#| eval: false
 #| echo: false
 #| output: true
 mice_pmm$imputed |> gtsummary::tbl_summary(by=".imp")
+
 ```
 
 ## CART
@@ -595,7 +596,7 @@ mice_pmm$imputed |> gtsummary::tbl_summary(by=".imp")
 #| label: tbl-imputation-summary-cart
 #| tbl-caption: Summary of data imputed via CART.
 #| purl: true
-#| eval: true
+#| eval: false
 #| echo: false
 #| output: true
 mice_cart$imputed |> gtsummary::tbl_summary(by=".imp")
@@ -608,7 +609,7 @@ mice_cart$imputed |> gtsummary::tbl_summary(by=".imp")
 #| label: tbl-imputation-summary-rf
 #| tbl-caption: Summary of data imputed via Random Forest.
 #| purl: true
-#| eval: true
+#| eval: false
 #| echo: false
 #| output: true
 mice_rf$imputed |> gtsummary::tbl_summary(by = ".imp")

--- a/sections/_imputation.qmd
+++ b/sections/_imputation.qmd
@@ -143,7 +143,10 @@ mice_rf <- impute_data(method = "rf",
                         imputations = imputations,
                         iterations = iterations,
                         seed = 3151358)
-
+## Save a copy of the imputed data (mice_*) for loading and using in analysis
+saveRDS(mice_pmm, file = paste(r_dir, "mice_pmm.rds", sep = "/"))
+saveRDS(mice_cart, file = paste(r_dir, "mice_cart.rds", sep = "/"))
+saveRDS(mice_rf, file = paste(r_dir, "mice_rf.rds", sep = "/"))
 
 ```
 

--- a/sections/_lasso.qmd
+++ b/sections/_lasso.qmd
@@ -17,7 +17,7 @@ tune_spec_lasso <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 1)
 lasso_grid <- tune::tune_grid(
   object = workflows::add_model(thyroid_workflow, tune_spec_lasso),
   resamples = cv_folds,
-  grid = dials::grid_regular(penalty(), levels = 50)
+  grid = dials::grid_regular(dials::penalty(), levels = 50)
 )
 ```
 

--- a/sections/_lasso_imputed.qmd
+++ b/sections/_lasso_imputed.qmd
@@ -1,0 +1,144 @@
+``` {.r}
+#| label: fig-imputed-pmm-lasso
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: false
+load(file = paste(r_dir, "imputed_cart_model_lasso.rds", sep = "/"))
+load(file = paste(r_dir, "imputed_pmm_model_lasso.rds", sep = "/"))
+load(file = paste(r_dir, "imputed_forest_model_lasso.rds", sep = "/"))
+
+```
+
+
+::: {.panel-tabset}
+
+## PMM
+
+``` {.r}
+#| label: fig-imputed-pmm-lasso
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| out-width: "80%"
+cowplot::plot_grid(imputed_pmm_model_lasso[[1]]$importance_plot,
+                   imputed_pmm_model_lasso[[1]]$train_roc_curve_plot,
+                   imputed_pmm_model_lasso[[1]]$test_roc_curve_plot,
+                   imputed_pmm_model_lasso[[2]]$importance_plot,
+                   imputed_pmm_model_lasso[[2]]$train_roc_curve_plot,
+                   imputed_pmm_model_lasso[[2]]$test_roc_curve_plot,
+                   imputed_pmm_model_lasso[[3]]$importance_plot,
+                   imputed_pmm_model_lasso[[3]]$train_roc_curve_plot,
+                   imputed_pmm_model_lasso[[3]]$test_roc_curve_plot,
+                   imputed_pmm_model_lasso[[4]]$importance_plot,
+                   imputed_pmm_model_lasso[[4]]$train_roc_curve_plot,
+                   imputed_pmm_model_lasso[[4]]$test_roc_curve_plot,
+                   imputed_pmm_model_lasso[[5]]$importance_plot,
+                   imputed_pmm_model_lasso[[5]]$train_roc_curve_plot,
+                   imputed_pmm_model_lasso[[5]]$test_roc_curve_plot,
+                   # labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 5,
+                   ncol = 3)
+
+```
+
+``` {.r}
+#| label: tab-imputed-pmm-lasso-importance
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Importance of features from LASSO model of five PMM imputed datasets."
+tidy_pmm_lasso$importance |>
+    knitr::kable(caption = "Importance of features from LASSO model of five PMM imputed datasets.")
+
+```
+
+``` {.r}
+#| label: tab-imputed-pmm-lasso-train-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five PMM imputed datasets (Training Data)."
+tidy_pmm_lasso$train_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five PMM imputed datasets (Training Data).",
+                 digits = 4)
+
+```
+
+``` {.r}
+#| label: tab-imputed-pmm-lasso-test-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five PMM imputed datasets (Testing Data)."
+tidy_pmm_lasso$test_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five PMM imputed datasets (Testing Data).",
+                 digits = 4)
+
+```
+
+## CART
+
+``` {.r}
+#| label: fig-imputed-cart-lasso
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| out-width: "80%"
+cowplot::plot_grid(imputed_cart_model_lasso[[1]]$importance_plot,
+                   imputed_cart_model_lasso[[1]]$train_roc_curve_plot,
+                   imputed_cart_model_lasso[[1]]$test_roc_curve_plot,
+                   imputed_cart_model_lasso[[2]]$importance_plot,
+                   imputed_cart_model_lasso[[2]]$train_roc_curve_plot,
+                   imputed_cart_model_lasso[[2]]$test_roc_curve_plot,
+                   imputed_cart_model_lasso[[3]]$importance_plot,
+                   imputed_cart_model_lasso[[3]]$train_roc_curve_plot,
+                   imputed_cart_model_lasso[[3]]$test_roc_curve_plot,
+                   imputed_cart_model_lasso[[4]]$importance_plot,
+                   imputed_cart_model_lasso[[4]]$train_roc_curve_plot,
+                   imputed_cart_model_lasso[[4]]$test_roc_curve_plot,
+                   imputed_cart_model_lasso[[5]]$importance_plot,
+                   imputed_cart_model_lasso[[5]]$train_roc_curve_plot,
+                   imputed_cart_model_lasso[[5]]$test_roc_curve_plot,
+                   # labels = c("PMM", "Cart", "Random Forest"),
+                   nrow = 5,
+                   ncol = 3)
+
+```
+
+## Random Forest
+
+``` {.r}
+#| label: fig-imputed-rf-lasso
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| out-width: "80%"
+cowplot::plot_grid(imputed_rf_model_lasso[[1]]$importance_plot,
+                   imputed_rf_model_lasso[[1]]$train_roc_curve_plot,
+                   imputed_rf_model_lasso[[1]]$test_roc_curve_plot,
+                   imputed_rf_model_lasso[[2]]$importance_plot,
+                   imputed_rf_model_lasso[[2]]$train_roc_curve_plot,
+                   imputed_rf_model_lasso[[2]]$test_roc_curve_plot,
+                   imputed_rf_model_lasso[[3]]$importance_plot,
+                   imputed_rf_model_lasso[[3]]$train_roc_curve_plot,
+                   imputed_rf_model_lasso[[3]]$test_roc_curve_plot,
+                   imputed_rf_model_lasso[[4]]$importance_plot,
+                   imputed_rf_model_lasso[[4]]$train_roc_curve_plot,
+                   imputed_rf_model_lasso[[4]]$test_roc_curve_plot,
+                   imputed_rf_model_lasso[[5]]$importance_plot,
+                   imputed_rf_model_lasso[[5]]$train_roc_curve_plot,
+                   imputed_rf_model_lasso[[5]]$test_roc_curve_plot,
+                   # labels = c("PMM", "Rf", "Random Forest"),
+                   nrow = 5,
+                   ncol = 3)
+
+```
+
+:::

--- a/sections/_modelling.qmd
+++ b/sections/_modelling.qmd
@@ -1,0 +1,309 @@
+```{r}
+#| label: source-custom-functions
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: false
+#| cache: false
+source("r/functions.R")
+```
+
+```{r}
+#| label: model-cart-imputed-lasso
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+cart_imputed <- mice_cart$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_cart_model_lasso <- cart_imputed |>
+    split(cart_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "elastic",
+        mixture = 1.0,
+        imputed = TRUE
+    ))
+tidy_cart_lasso <- tidy_imputed_models(imputed_cart_model_lasso, model_type="elastic")
+save(imputed_cart_model_lasso,
+     tidy_cart_lasso,
+     file = paste(r_dir, "imputed_cart_model_lasso.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-rf-imputed-lasso
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+rf_imputed <- mice_rf$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_rf_model_lasso <- rf_imputed |>
+    split(rf_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "elastic",
+        mixture = 1.0,
+        imputed = TRUE
+    ))
+tidy_rf_lasso <- tidy_imputed_models(imputed_rf_model_lasso, model_type="elastic")
+save(imputed_rf_model_lasso,
+     tidy_rf_lasso,
+     file = paste(r_dir, "imputed_rf_model_lasso.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-pmm-imputed-lasso
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+pmm_imputed <- mice_pmm$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_pmm_model_lasso <- pmm_imputed |>
+    split(pmm_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "elastic",
+        mixture = 1.0,
+        imputed = TRUE
+    ))
+tidy_pmm_lasso <- tidy_imputed_models(imputed_pmm_model_lasso, model_type="elastic")
+save(imputed_pmm_model_lasso,
+     tidy_pmm_lasso,
+     file = paste(r_dir, "imputed_pmm_model_lasso.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-cart-imputed-elastic
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+cart_imputed <- mice_cart$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_cart_model_elastic <- cart_imputed |>
+    split(cart_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "elastic",
+        mixture = 0.5,
+        imputed = TRUE
+    ))
+tidy_cart_elastic <- tidy_imputed_models(imputed_cart_model_elastic, model_type="elastic")
+save(imputed_cart_model_elastic,
+     tidy_cart_elastic,
+     file = paste(r_dir, "imputed_cart_model_elastic.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-rf-imputed-elastic
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+rf_imputed <- mice_rf$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_rf_model_elastic <- rf_imputed |>
+    split(rf_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "elastic",
+        mixture = 0.5,
+        imputed = TRUE
+    ))
+tidy_rf_elastic <- tidy_imputed_models(imputed_rf_model_elastic, model_type="elastic")
+save(imputed_rf_model_elastic,
+     tidy_rf_elastic,
+     file = paste(r_dir, "imputed_rf_model_elastic.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-pmm-imputed-elastic
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+pmm_imputed <- mice_pmm$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_pmm_model_elastic <- pmm_imputed |>
+    split(pmm_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "elastic",
+        mixture = 0.5,
+        imputed = TRUE
+    ))
+tidy_pmm_elastic <- tidy_imputed_models(imputed_pmm_model_elastic, model_type="elastic")
+save(imputed_pmm_model_elastic,
+     tidy_pmm_elastic,
+     file = paste(r_dir, "imputed_pmm_model_elastic.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-cart-imputed-forest
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+cart_imputed <- mice_cart$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_cart_model_forest <- cart_imputed |>
+    split(cart_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "forest",
+        mixture = 0.5,
+        imputed = TRUE
+    ))
+tidy_cart_forest <- tidy_imputed_models(imputed_cart_model_forest, model_type="forest")
+save(imputed_cart_model_forest,
+     tidy_cart_forest,
+     file = paste(r_dir, "imputed_cart_model_forest.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-rf-imputed-forest
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+rf_imputed <- mice_rf$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_rf_model_forest <- rf_imputed |>
+    split(rf_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "forest",
+        mixture = 0.5,
+        imputed = TRUE
+    ))
+tidy_rf_forest <- tidy_imputed_models(imputed_rf_model_forest, model_type="forest")
+save(imputed_rf_model_forest,
+     tidy_rf_forest,
+     file = paste(r_dir, "imputed_rf_model_forest.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-pmm-imputed-forest
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+pmm_imputed <- mice_pmm$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_pmm_model_forest <- pmm_imputed |>
+    split(pmm_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "forest",
+        mixture = 0.5,
+        imputed = TRUE
+    ))
+tidy_pmm_forest <- tidy_imputed_models(imputed_pmm_model_forest, model_type="forest")
+save(imputed_pmm_model_forest,
+     tidy_pmm_forest,
+     file = paste(r_dir, "imputed_pmm_model_forest.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-cart-imputed-xgboost
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+cart_imputed <- mice_cart$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_cart_model_xgboost <- cart_imputed |>
+    split(cart_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "xgboost",
+        mixture = 0.5,
+        imputed = TRUE
+    ))
+tidy_cart_xgboost <- tidy_imputed_models(imputed_cart_model_xgboost, model_type="xgboost")
+save(imputed_cart_model_xgboost,
+     tidy_cart_xgboost,
+     file = paste(r_dir, "imputed_cart_model_xgboost.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-rf-imputed-xgboost
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+rf_imputed <- mice_rf$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_rf_model_xgboost <- rf_imputed |>
+    split(rf_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "xgboost",
+        mixture = 0.5,
+        imputed = TRUE
+    ))
+tidy_rf_xgboost <- tidy_imputed_models(imputed_rf_model_xgboost, model_type="xgboost")
+save(imputed_rf_model_xgboost,
+     tidy_rf_xgboost,
+     file = paste(r_dir, "imputed_rf_model_xgboost.rds", sep = "/"))
+
+```
+
+```{r}
+#| label: model-pmm-imputed-xgboost
+#| purl: true
+#| eval: false
+#| echo: false
+#| output: false
+#| cache: true
+pmm_imputed <- mice_pmm$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp))
+imputed_pmm_model_xgboost <- pmm_imputed |>
+    split(pmm_imputed$.imp) |>
+    purrr::map(\(df) model_fitting(df,
+    ## furrr::future_map(\(df) model_fitting(df,
+        model_type = "xgboost",
+        mixture = 0.5,
+        imputed = TRUE
+    ))
+tidy_pmm_xgboost <- tidy_imputed_models(imputed_pmm_model_xgboost, model_type="xgboost")
+save(imputed_pmm_model_xgboost,
+     tidy_pmm_xgboost,
+     file = paste(r_dir, "imputed_pmm_model_xgboost.rds", sep = "/"))
+
+```

--- a/sections/_recipe.qmd
+++ b/sections/_recipe.qmd
@@ -13,12 +13,10 @@ set.seed(5039378)
 ## Use df_complete rather than df as this subset have data for all the variables of interest.
 ## split <- rsample::initial_split(df_complete, prop = 0.75)
 ## @ns-rse (2024-07-18) - Use an imputed dataset instead
-split <- mice_rf$imputed |>
-    dplyr::filter(.imp == 1) |>
-    dplyr::select(-.imp, -.id) |>
+df_split <- df_complete |>
     rsample::initial_split(prop = 0.75)
-train <- rsample::training(split)
-test <- rsample::testing(split)
+train <- rsample::training(df_split)
+test <- rsample::testing(df_split)
 ```
 
 ```{r}

--- a/sections/_recipe_imputed.qmd
+++ b/sections/_recipe_imputed.qmd
@@ -1,0 +1,98 @@
+```{r}
+#| label: test-train-split-imputed
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: false
+## Prefer tidymodel commands (although in most places we use the convention <pkg>::<function>())
+library(tidyverse)
+library(tidymodels)
+tidymodels::tidymodels_prefer()
+set.seed(5039378)
+
+## !!!!!!README!!!!!!
+##
+## I'm new to using purrr but from what I can work out/understand so far and the way we want to use it we start with a
+## dataset that is piped into purrr::map() the first thing we do is then define how we will refer to this dataset using
+## the notation `\(<some_name>)` we then provide a function we wish to apply to each split of the data and use
+## `<some_name>` as an argument to that function.
+
+## Use an imputed data set (cart) and purrr::map() to apply the split to each imputed dataset. We first remove the
+## "Original" that is included in the data and the .id variable
+## purrr_split is a list of data frames.
+cart_imputed <- mice_cart$imputed |>
+    dplyr::filter(.imp != "Original") |>
+    dplyr::mutate(.imp = droplevels(.imp)) |>
+    dplyr::select(-.id)
+purrr_split <- cart_imputed |>
+    split(cart_imputed$.imp) |>
+    purrr::map(\(df) rsample::initial_split(df, prop = 0.75))
+
+## This does the same but includes "Original", which we know won't work well due to missing data.
+## purrr_split <- mice_cart$imputed |>
+##     split(mice_cart$imputed$.imp) |>
+##     purrr::map(\(df) rsample::initial_split(df, prop = 0.75))
+
+## Then derive a training and test dataset for each imputed dataset.
+## purrr_train and purrr_test are again lists of data frames.
+purrr_train <- purrr_split |>
+    purrr::map(\(split) rsample::training(split))
+purrr_test <- purrr_split |>
+    purrr::map(\(split) rsample::test(split))
+
+```
+
+```{r}
+#| label: cv-vfold-imputed
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: false
+## Again use purr to map
+purrr_cv_folds <- purrr_train |>
+    purrr::map(\(df) rsample::vfold_cv(df, v = 10, repeats = 10))
+```
+
+```{r}
+#| label: cv-loo-imputed
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: false
+purrr_cv_loo <- purrr_train |>
+    purrr::map(\(df) rsample::loo_cv(df, v = 10, repeats = 10))
+```
+
+```{r}
+#| label: recipe-imputed
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: false
+purrr_thyroid_recipe_imputed <- purrr_train |>
+    purrr::map(\(df) recipes::recipe(final_pathology ~ ., data = df)) |>
+    ## @ns-rse 2024-08-01 :
+    ## We don't need to filter missing because we are using imputed datasets
+    ## https://recipes.tidymodels.org/reference/step_filter_missing.html
+    ## recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+    purrr::map(\(df) recipes::step_normalize(df, recipes::all_numeric_predictors())) |>
+    purrr::map(\(df) recipes::step_dummy(df, recipes::all_nominal_predictors()))
+
+## !!!!!!INFO!!!!!!
+##
+## You can look at purrr_thyroid_recipe_imputed and see it is a list of two identical recipes (just enter
+## 'purrr_thyroid_recipe_imputed' without quotes at the R console and hit Return)
+```
+
+```{r}
+#| label: workflow-imputed
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: false
+## !!!!!!WARNING!!!!!! This section isn't yet working
+purrr_thyroid_workflow_imputed <- purrr_thyroid_recipe_imputed |>
+    ## purrr::map(\(recipe) workflows::workflow()) |>
+    purrr::map(\(recipe) workflows::add_recipe(recipe), workflows::workflow())
+saveRDS(thyroid_workflow, file = paste(r_dir, "thyroid_workflow.rds", sep = "/"))
+```

--- a/sections/_recipe_imputed.qmd
+++ b/sections/_recipe_imputed.qmd
@@ -30,6 +30,7 @@ purrr_split <- cart_imputed |>
 
 ## This does the same but includes "Original", which we know won't work well due to missing data.
 ## purrr_split <- mice_cart$imputed |>
+##     dplyr::select(-.id) |>
 ##     split(mice_cart$imputed$.imp) |>
 ##     purrr::map(\(df) rsample::initial_split(df, prop = 0.75))
 
@@ -38,7 +39,7 @@ purrr_split <- cart_imputed |>
 purrr_train <- purrr_split |>
     purrr::map(\(split) rsample::training(split))
 purrr_test <- purrr_split |>
-    purrr::map(\(split) rsample::test(split))
+    purrr::map(\(split) rsample::testing(split))
 
 ```
 
@@ -48,7 +49,7 @@ purrr_test <- purrr_split |>
 #| eval: true
 #| echo: false
 #| output: false
-## Again use purr to map
+## Again use purrr to map the training datasets onto vfold cross validation
 purrr_cv_folds <- purrr_train |>
     purrr::map(\(df) rsample::vfold_cv(df, v = 10, repeats = 10))
 ```
@@ -59,8 +60,9 @@ purrr_cv_folds <- purrr_train |>
 #| eval: true
 #| echo: false
 #| output: false
+## Or we can use purrr to map the training datasets onto leave one out cross validation
 purrr_cv_loo <- purrr_train |>
-    purrr::map(\(df) rsample::loo_cv(df, v = 10, repeats = 10))
+    purrr::map(\(df) rsample::loo_cv(df))
 ```
 
 ```{r}
@@ -80,8 +82,10 @@ purrr_thyroid_recipe_imputed <- purrr_train |>
 
 ## !!!!!!INFO!!!!!!
 ##
-## You can look at purrr_thyroid_recipe_imputed and see it is a list of two identical recipes (just enter
-## 'purrr_thyroid_recipe_imputed' without quotes at the R console and hit Return)
+## You can look at purrr_thyroid_recipe_imputed (just enter  'purrr_thyroid_recipe_imputed' without quotes at the R
+## console and hit Return). It is a list of recipes, each has one outcome variable ('final_thyroid') and 23 predictors.
+## There are two operations to be performed, one is to center and scale numeric predictors, the other is to create dummy
+## variables for all nominal predictors.
 ```
 
 ```{r}
@@ -90,9 +94,31 @@ purrr_thyroid_recipe_imputed <- purrr_train |>
 #| eval: true
 #| echo: false
 #| output: false
-## !!!!!!WARNING!!!!!! This section isn't yet working
 purrr_thyroid_workflow_imputed <- purrr_thyroid_recipe_imputed |>
-    ## purrr::map(\(recipe) workflows::workflow()) |>
-    purrr::map(\(recipe) workflows::add_recipe(recipe), workflows::workflow())
+    purrr::map(\(recipe) workflows::workflow()) |>
 saveRDS(thyroid_workflow, file = paste(r_dir, "thyroid_workflow.rds", sep = "/"))
+```
+
+```{r}
+#| label: workflow-imputed
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: false
+tune_spec_elastic <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 0.5) |>
+  parsnip::set_engine("glmnet")
+## We must make a list of our workflow and cross validation and use purrr:pmap() to pass both into tune::tune_grid()
+l <- list(workflow = purrr_thyroid_workflow_imputed, resamples = purrr_cv_folds)
+purrr_elastic_grid_imputed <-
+    purrr::pmap(l,
+               tune::tune_grid(
+                   object = workflows::add_model(workflow, tune_spec_elastic),
+                   resamples = resamples,
+                   grid = dials::grid_regular(penalty(), levels = 50)))
+#purrr_elastic_grid_imputed <- purrr_thyroid_workflow_imputed |>
+#    purrr::pmap(\(workflow),
+#               tune::tune_grid(
+#                   object = workflows::add_model(workflow, tune_spec_elastic),
+#                   resamples = ,
+#                   grid = dials::grid_regular(penalty(), levels = 50)))
 ```

--- a/sections/_rforest.qmd
+++ b/sections/_rforest.qmd
@@ -9,20 +9,20 @@
 #| output: false
 ## Specify the Random Forest model
 rf_tune <- parsnip::rand_forest(
-  mtry = tune(),
+  mtry = hardhat::tune(),
   trees = 100,
-  min_n = tune()
+  min_n = hardhat::tune()
 ) |>
-  set_mode("classification") |>
-  set_engine("ranger", importance = "impurity")
+  parsnip::set_mode("classification") |>
+  parsnip::set_engine("ranger", importance = "impurity")
 
 
 ## Tune the parameters via Cross-validation
 rf_grid <- tune::tune_grid(
   add_model(thyroid_workflow, rf_tune),
   resamples = cv_folds, ## cv_loo,
-  grid = grid_regular(mtry(range = c(5, 10)), # smaller ranges will run quicker
-    min_n(range = c(2, 25)),
+  grid = grid_regular(dials::mtry(range = c(5, 10)), # smaller ranges will run quicker
+    dials::min_n(range = c(2, 25)),
     levels = 3
   )
 )

--- a/tmp/scratch.R
+++ b/tmp/scratch.R
@@ -1,0 +1,840 @@
+library(dplyr)
+library(ggplot2)
+library(ggdark)
+library(gtsummary)
+library(Hmisc)
+library(knitr)
+library(readr)
+library(rmarkdown)
+library(visdat)
+library(naniar)
+library(purrr)
+
+## Libraries for Tidymodelling
+library(dials)
+library(kernlab)
+library(knitr)
+library(tidymodels)
+library(tidyverse)
+library(vip)
+
+## Load and retain only those with final_pathology
+df <- readRDS(paste(r_dir, "clean.rds", sep = "/"))
+df_complete <- readRDS(paste(r_dir, "df_complete.rds", sep = "/"))
+mice_pmm <- readRDS(file = paste(r_dir, "mice_pmm.rds", sep = "/"))
+mice_cart <- readRDS(file = paste(r_dir, "mice_cart.rds", sep = "/"))
+mice_rf <- readRDS(file = paste(r_dir, "mice_rf.rds", sep = "/"))
+
+####################################################
+## 2024-09-20 - Purrr alternative, write a function
+##              that does the modelling and map that
+####################################################
+#' Function for fitting different models to a dataset
+#'
+#' For this work we want to fit models to datasets that have been imputed using the MICE package
+#'
+#' @df data.frame Dataframe to be analysed
+#' @imputed logical Whether the data frame is an imputed data set
+#' @prop float Proportion to split the data by for training/testing. Default is 0.75
+#' @v int Number of folds for cross-validation. Default is 10.
+#' @repeats int Number of repeats for cross-validation. Default is 10.
+#' @missing_threshold float Proportion of missing data allowed, used in 'recipes::step_filter_missing()'. Default is 0
+#' @outcome Outcome variable
+#' @continuous vector Vector of continuous predictor variables.
+#' @categorical vector Vector of categorical/nominal predictor variables.
+#' @model_type str The type of model to fit, options are 'elastic', 'lasso' 'xgboost', 'svm'
+#' ... Hyperparameters to pass to the selected model_type
+#'
+#' @seealso [mice]
+#' @export
+#' @examples
+model_fitting <- function(df,
+                          imputed = TRUE,
+                          prop = 0.75,
+                          v = 10,
+                          repeats = 10,
+                          missing_threshold = 0.0,
+                          outcome = "final_pathology",
+                          continuous = c("albumin", "tsh_value", "lymphocytes", "monocyte", "size_nodule_mm"),
+                          categorical = c("ethnicity",
+                                          "incidental_nodule",
+                                          "palpable_nodule",
+                                          "rapid_enlargement",
+                                          "compressive_symptoms",
+                                          "hypertension",
+                                          "vocal_cord_paresis",
+                                          "graves_disease",
+                                          "hashimotos_thyroiditis",
+                                          "family_history_thyroid_cancer",
+                                          "exposure_radiation",
+                                          "bta_u_classification",
+                                          "solitary_nodule",
+                                          "cervical_lymphadenopathy",
+                                          "thy_classification"),
+                          model_type = "lasso",
+                          ...
+) {
+  ## If this is an imputed dataset we need to remove -.imp and -.id variables
+  if(imputed) {
+    df <- df |>
+      dplyr::select(-.imp, -.id)
+  }
+  ## Select the variables of interest
+  df <- df |>
+    dplyr::select({{ outcome }}, {{ continuous }}, {{ categorical }})
+  ## Split the data into training and test data
+  split <- df |>
+    rsample::initial_split(prop = prop)
+  train <- rsample::training(split)
+  test <- rsample::testing(split)
+  ## Create k-fold validation on training data
+  cv_folds <- rsample::vfold_cv(train, v = v, repeats = repeats)
+  ## Setup a recipe, the steps involved removing individuals with missing data
+  ## ns-rse 2024-09-20 : Ideally we shouldn't have final_pathology hard coded here but the "embrace" method of
+  ## indirection (see vignette("programmin")) doesn't seem to work with recipes. Online example of creating own recipe
+  ## step function (https://www.tidymodels.org/learn/develop/recipes/index.html#create-the-function) uses the older
+  ## enquos() method
+  thyroid_recipe <- recipes::recipe(final_pathology ~ ., data = train) |>
+    recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_dummy(recipes::all_nominal_predictors())
+  ## Add recipe to a workrlow
+  thyroid_workflow <- workflows::workflow() |>
+    workflows::add_recipe(thyroid_recipe)
+  ## Conditionally fit the model based on the requested method, this involves setting up a parsnip model specification
+  ## and then tune it via tune::tune_grid()
+  ## @ns-rse 2024-09-20 : Refactor and abstract out common components have parsnip::() and grid_regular() set in each
+  ## conditional section and a final tune::tune_grid() that takes whatever these values are set to.
+  if(model_type == "lasso") {
+    print("Fitting LASSO")
+    tune_spec <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 1) |>
+      parsnip::set_engine("glmnet")
+    dials_grid <- dials::grid_regular(dials::penalty(), levels = 50)
+    grid <- tune::tune_grid(
+                    object = workflows::add_model(thyroid_workflow, tune_spec),
+                    resamples = cv_folds,
+                    grid = dials_grid
+                  )
+  } else if(model_type == "elastic") {
+    print("Fitting Elastic Net")
+    parsnip_tune <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 0.5) |>
+      parsnip::set_engine("glmnet")
+    dials_grid <- dials::grid_regular(dials::penalty(), levels = 50)
+    grid <- tune::tune_grid(
+                    object = workflows::add_model(thyroid_workflow, parsnip_tune),
+                    resamples = cv_folds,
+                    grid = dials_grid
+                  )
+  } else if(model_type == "forest") {
+    print("Fitting Random Forest")
+    ## @ns-rse 2024-09-20 : For flexibility we could set things up to specify different engines here
+    parsnip_tune <- parsnip::rand_forest(
+                          mtry = hardhat::tune(),
+                          trees = 100,
+                          min_n = hardhat::tune()
+                        ) |>
+      parsnip::set_mode("classification") |>
+      parsnip::set_engine("ranger", importance = "impurity")
+    dials_grid <- dials::grid_regular(
+                           dials::mtry(range = c(5, 10)), # smaller ranges will run quicker
+                           dials::min_n(range = c(2, 25)),
+                           levels = 3
+                         )
+    grid <- tune::tune_grid(
+                    object = workflows::add_model(thyroid_workflow, parsnip_tune),
+                    resamples = cv_folds,
+                    grid = dials_grid
+                  )
+  } else if(model_type == "xgboost") {
+    print("Fitting Gradient Boosting")
+    parsnip_tune <- parsnip::boost_tree(
+                                mode = "classification",
+                                trees = 100,
+                                min_n = hardhat::tune(),
+                                tree_depth = hardhat::tune(),
+                                learn_rate = hardhat::tune(),
+                                loss_reduction = hardhat::tune()
+                              ) |>
+      set_engine("xgboost", objective = "binary:logistic")
+    ## Specify the models tuning parameters using the `dials` package along (https://dials.tidymodels.org/) with the grid
+    ## space. This helps identify the hyperparameters with the lowest prediction error.
+    dials_params <- dials::parameters(
+                               dials::min_n(),
+                               dials::tree_depth(),
+                               dials::learn_rate(),
+                               dials::loss_reduction()
+                             )
+    dials_grid <- dials::grid_max_entropy(
+                     dials_params,
+                     size = 10
+                     )
+    yardstick_metrics <- yardstick::metric_set(yardstick::roc_auc, yardstick::accuracy, yardstick::ppv)
+    grid <- tune::tune_grid(
+                    workflows::add_model(thyroid_workflow, spec = parsnip_tune),
+                    resamples = cv_folds,
+                    grid = dials_grid,
+                    metrics = yardstick_metrics,
+                    control = tune::control_grid(verbose = FALSE)
+                  )
+  } else if(model_type == "svm") {
+    print("Fitting Support Vector Machine")
+    parsnip_tune <- parsnip::svm_rbf(cost = tune()) |>
+      set_engine("kernlab") |>
+      set_mode("classification")
+    dials_grid <- dials::grid_regular(dials::cost(), levels = 20)
+    svm_grid <- tune::tune_grid(
+                        workflows::add_model(thyroid_workflow, parsnip_tune),
+                        resamples = cv_folds, ## cv_loo,
+                        grid = dials_grid
+                      )
+  }
+}
+mice_cart$imputed |>
+  dplyr::filter(.imp == 1) |>
+  ## model_fitting(model_type = "lasso")
+  ## model_fitting(model_type = "elastic")
+  ## model_fitting(model_type = "forest")
+  ## model_fitting(model_type = "xgboost")
+  model_fitting(model_type = "svm")
+
+
+####################################################
+## 2024-09-19 - Purrr with MICE
+####################################################
+library(tidyverse)
+library(tidymodels)
+library(mice)
+## Make some missing data
+iris[16, 2] <- as.numeric(NA)
+iris[46, 2] <- as.numeric(NA)
+iris[76, 2] <- as.numeric(NA)
+
+iris[96, 2] <- as.numeric(NA)
+iris[106, 2] <- as.numeric(NA)
+iris[18, 3] <- as.numeric(NA)
+iris[48, 3] <- as.numeric(NA)
+iris[78, 3] <- as.numeric(NA)
+iris[98, 3] <- as.numeric(NA)
+iris[108, 3] <- as.numeric(NA)
+iris[9, 4] <- as.numeric(NA)
+iris[29, 4] <- as.numeric(NA)
+iris[69, 4] <- as.numeric(NA)
+iris[89, 4] <- as.numeric(NA)
+iris[109, 4] <- as.numeric(NA)
+iris[129, 4] <- as.numeric(NA)
+
+## Impute missing values
+imputations <- 4
+iterations <- 5
+seed <- 238992
+mids <- iris |>
+  dplyr::select(-Sepal.Length) |>
+  mice::futuremice(
+    m = imputations,
+    method = "cart",
+    iterations = iterations,
+    n.core = imputations,
+    parallelseed = seed
+  )
+## Generate imputed dataset
+imputed <- mids |>
+  mice::complete(action = "long", include = TRUE)
+## Convert .imp variable which indicates the imputation set to factor with original dataset labelled as such
+imputed <- imputed |>
+  dplyr::mutate(.imp = factor(.imp,
+    levels = seq(0, imputations, 1),
+    labels = c("Original", as.character(seq(1, imputations, 1)))
+  ))
+## Bind the Sepal.length to each dataset of imputed (including original)
+outcome = iris[["Sepal.Length"]]
+n <- imputations
+while (n > 0) {
+  outcome <- append(outcome, iris[["Sepal.Length"]])
+  n <- n - 1
+}
+imputed <- cbind(imputed, outcome)
+## Sort out column names
+colnames(imputed) <- stringr::str_replace(colnames(imputed), "outcome", "Sepal.Length")
+
+## We now have six data sets in imputed differentiated by the .imp variable.names
+
+## Make a recipe and workflow to analyse each of these.
+set.seed(5039378)
+## Split the data
+purrr_split_iris <- imputed |>
+    dplyr::select(-.id) |>
+    split(imputed$.imp) |>
+    purrr::map(\(df) rsample::initial_split(df, prop = 0.75))
+purrr_train_iris <- purrr_split_iris |>
+    purrr::map(\(split) rsample::training(split))
+purrr_test_iris <- purrr_split_iris |>
+    purrr::map(\(split) rsample::testing(split))
+
+## Define k-fold cross validation
+purrr_cv_iris <- purrr_train_iris|>
+    purrr::map(\(df) rsample::vfold_cv(df, v = 10, repeats = 10))
+
+## Define a recipe adding steps to normalize numeric variables and create dummies for nominal variables
+purrr_recipe_iris <- purrr_train_iris |>
+    purrr::map(\(df) recipes::recipe(Sepal.Length ~ ., data = df)) |>
+    purrr::map(\(df) recipes::step_normalize(df, recipes::all_numeric_predictors())) |>
+    purrr::map(\(df) recipes::step_dummy(df, recipes::all_nominal_predictors()))
+
+####################################################
+## 2024-09-03 - Purrr with MICE
+####################################################
+## Load imputed data set (two imputations)
+mice_cart <- readRDS(paste(r_dir, "mice_cart.rds", sep = "/"))
+purrr_split <- mice_cart$imputed |>
+    split(mice_cart$imputed$.imp) |>
+    purrr::map(\(df) rsample::initial_split(df, prop = 0.75))
+
+purrr_train <- purrr_split |>
+    purrr::map(\(split) rsample::training(split))
+purrr_test <- purrr_split |>
+    purrr::map(\(split) rsample::testing(split))
+
+split <- mice_rf$imputed |>
+    dplyr::filter(.imp == 1) |>
+    dplyr::select(-.imp, -.id) |>
+    rsample::initial_split(prop = 0.75)
+train <- rsample::training(split)
+test <- rsample::testing(split)
+
+####################################################
+## 2024-07-19 - Why aren't different imputation methods giving different numbers
+####################################################
+
+## Old method
+test_pmm <- df_complete |>
+    dplyr::select(-final_pathology) |>    ## We deliberately exclude the outcome of interest
+    mice::futuremice(m = imputations, method="pmm", n.core=cores) |>
+    mice::complete(action = "long", include = TRUE)
+test_pmm <- dplyr::mutate(test_pmm, .imp = factor(.imp, levels = c(0,1,2,3,4), labels = c("Original", "1", "2", "3", "4")))
+## CART (Classification And Regression Trees)
+test_cart <- df_complete |>
+    dplyr::select(-final_pathology) |>    ## We deliberately exclude the outcome of interest
+    mice::futuremice(m = imputations, method="cart", n.core=cores) |>
+    mice::complete(action = "long", include = TRUE)
+test_cart <- dplyr::mutate(test_cart, .imp = factor(.imp, levels = c(0,1,2,3,4), labels = c("Original", "1", "2", "3", "4")))
+## Random Forest
+test_rf <- df_complete |>
+    dplyr::select(-final_pathology) |>    ## We deliberately exclude the outcome of interest
+    mice::futuremice(m = imputations, method="rf", n.core=cores) |>
+    mice::complete(action = "long", include = TRUE)
+test_rf <- dplyr::mutate(test_rf, .imp = factor(.imp, levels = c(0,1,2,3,4), labels = c("Original", "1", "2", "3", "4")))
+
+####################################################
+## 2024-07-18 - Investigating with recipes::step_unknown()
+####################################################
+split <- df_complete|>
+    rsample::initial_split(prop = 0.75)
+train <- rsample::training(split)
+test <- rsample::testing(split)
+
+## Without removing anything what doe we have
+thyroid_recipe <- recipes::recipe(final_pathology ~ ., data = train) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_dummy(recipes::all_nominal_predictors()) |>
+    recipes::prep() |>
+    recipes::bake(new_data = NULL)
+str(thyroid_recipe)
+
+## Setup a recipe and workflow that...
+##    + normalize numeric variables
+##    + creates dummy variables for nominal (binary/continuous) variables
+##    + removes variables that have correlation > 0.9
+thyroid_recipe_step_unknown <- recipes::recipe(final_pathology ~ ., data = train) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_unknown(recipes::all_nominal_predictors(), new_level = "unknown") |>
+    recipes::step_dummy(recipes::all_nominal_predictors()) |>
+    recipes::prep() |>
+    recipes::bake(new_data = NULL)
+str(thyroid_recipe_step_unknown)
+
+## Compare the packages
+waldo::compare(thyroid_recipe, thyroid_recipe_step_unknown)
+
+## Try fitting a model
+thyroid_recipe_step_unknown <- recipes::recipe(final_pathology ~ ., data = train) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_unknown(recipes::all_nominal_predictors(), new_level = "unknown") |>
+    recipes::step_dummy(recipes::all_nominal_predictors())
+thyroid_workflow <- workflows::workflow() |>
+  workflows::add_recipe(thyroid_recipe_step_unknown)
+cv_folds <- rsample::vfold_cv(train, v = 10, repeats = 10)
+tune_spec_lasso <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 1) |>
+  parsnip::set_engine("glmnet")
+## Tune the LASSO parameters via cross-validation
+lasso_grid <- tune::tune_grid(
+  object = workflows::add_model(thyroid_workflow, tune_spec_lasso),
+  resamples = cv_folds,
+  grid = dials::grid_regular(penalty(), levels = 50)
+)
+
+####################################################
+## 2024-07-18 - Investigating with recipes::step_corr()
+####################################################
+split <- df_complete|>
+    rsample::initial_split(prop = 0.75)
+train <- rsample::training(split)
+test <- rsample::testing(split)
+
+## Without removing anything what doe we have
+thyroid_recipe <- recipes::recipe(final_pathology ~ ., data = train) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_dummy(recipes::all_nominal_predictors()) |>
+    recipes::prep() |>
+    recipes::bake(new_data = NULL)
+str(thyroid_recipe)
+
+## Setup a recipe and workflow that...
+##    + normalize numeric variables
+##    + creates dummy variables for nominal (binary/continuous) variables
+##    + removes variables that have correlation > 0.9
+thyroid_recipe_step_corr <- recipes::recipe(final_pathology ~ ., data = train) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_dummy(recipes::all_nominal_predictors()) |>
+    recipes::step_corr(all_predictors(), threshold = 0.9) |>
+    recipes::prep() |>
+    recipes::bake(new_data = NULL)
+str(thyroid_recipe_step_corr)
+
+## Compare the packages
+waldo::compare(thyroid_recipe, thyroid_recipe_step_corr)
+
+####################################################
+## 2024-07-18 - Investigating with recipes::prep() and recipes::bake()
+####################################################
+split <- df_complete|>
+    rsample::initial_split(prop = 0.75)
+train <- rsample::training(split)
+test <- rsample::testing(split)
+
+## Setup a recipe and workflow with all steps
+thyroid_recipe_all<- recipes::recipe(final_pathology ~ ., data = train) |>
+    recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_dummy(recipes::all_nominal_predictors()) |>
+    recipes::prep()
+all <- thyroid_recipe_all |> bake(new_data = NULL)
+str(all)
+
+## Setup a recipe and workflow with all steps increasing threshold for missing predictors
+thyroid_recipe_high_missing_threshold<- recipes::recipe(final_pathology ~ ., data = train) |>
+    recipes::step_filter_missing(recipes::all_predictors(), threshold = 0.5) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_dummy(recipes::all_nominal_predictors()) |>
+    recipes::prep()
+high_missing_threshold <- thyroid_recipe_high_missing_threshold |> bake(new_data = NULL)
+str(high_missing_threshold)
+
+## Setup a recipe and workflow with all steps increasing threshold for missing predictors
+thyroid_recipe_skip_filter_missing <- recipes::recipe(final_pathology ~ ., data = train) |>
+    ## recipes::step_filter_missing(recipes::all_predictors(), threshold = 0, skip = TRUE) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_dummy(recipes::all_nominal_predictors()) |>
+    recipes::prep()
+skip_filter_missing<- thyroid_recipe_skip_filter_missing |> bake(new_data = NULL)
+str(skip_filter_missing)
+
+## Setup a recipe and workflow with all steps increasing threshold for missing predictors
+thyroid_recipe_investigate_missing_threshold<- recipes::recipe(final_pathology ~ ., data = train) |>
+    recipes::step_filter_missing(recipes::all_predictors(), threshold = 0.1) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_dummy(recipes::all_nominal_predictors()) |>
+    recipes::prep()
+investigate_missing_threshold <- thyroid_recipe_investigate_missing_threshold |> bake(new_data = NULL)
+str(investigate_missing_threshold)
+
+## Test fitting a model using higher threshold
+thyroid_recipe_investigate_missing_threshold<- recipes::recipe(final_pathology ~ ., data = train) |>
+    recipes::step_filter_missing(recipes::all_predictors(), threshold = 0.1) |>
+    recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_dummy(recipes::all_nominal_predictors())
+thyroid_workflow <- workflows::workflow() |>
+  workflows::add_recipe(thyroid_recipe_investigate_missing_threshold)
+cv_folds <- rsample::vfold_cv(train, v = 10, repeats = 10)
+tune_spec_lasso <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 1) |>
+  parsnip::set_engine("glmnet")
+## Tune the LASSO parameters via cross-validation
+lasso_grid <- tune::tune_grid(
+  object = workflows::add_model(thyroid_workflow, tune_spec_lasso),
+  resamples = cv_folds,
+  grid = dials::grid_regular(penalty(), levels = 50)
+)
+## K-fold best fit for LASSO
+lasso_kfold_roc_auc <- lasso_grid |>
+  tune::select_best(metric = "roc_auc")
+
+
+## Fit the final LASSO model
+final_lasso_kfold <- tune::finalize_workflow(
+  workflows::add_model(thyroid_workflow, tune_spec_lasso),
+  lasso_kfold_roc_auc)
+
+final_lasso_kfold |>
+  fit(train) |>
+  hardhat::extract_fit_parsnip() |>
+  vip::vi(lambda = lasso_kfold_roc_auc$penalty) |>
+  dplyr::mutate(
+    Importance = abs(Importance),
+    Variable = fct_reorder(Variable, Importance)
+  ) |>
+  ggplot(mapping = aes(x = Importance, y = Variable, fill = Sign)) +
+  geom_col() +
+  dark_theme_minimal()
+ggplot2::ggsave("tmp/lasso_exclude_step_filter_missing.png")
+
+####################################################
+## 2024-07-18 - Testing without the `step_filter_missing()`
+####################################################
+split <- df_complete|>
+    rsample::initial_split(prop = 0.75)
+train <- rsample::training(split)
+test <- rsample::testing(split)
+
+## Setup cross-validation with k-folds (n = 10)
+cv_folds <- rsample::vfold_cv(train, v = 10, repeats = 10)
+
+
+## Setup a recipe and workflow
+thyroid_recipe <- recipes::recipe(final_pathology ~ ., data = train) |>
+  recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+  recipes::step_normalize(recipes::all_numeric_predictors()) |>
+    recipes::step_dummy(recipes::all_nominal_predictors()) |>
+    recipes::prep()
+thyroid_workflow <- workflows::workflow() |>
+  workflows::add_recipe(thyroid_recipe)
+
+## Try tuning a LASSO model
+tune_spec_lasso <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 1) |>
+  parsnip::set_engine("glmnet")
+
+## Tune the LASSO parameters via cross-validation
+lasso_grid <- tune::tune_grid(
+  object = workflows::add_model(thyroid_workflow, tune_spec_lasso),
+  resamples = cv_folds,
+  grid = dials::grid_regular(penalty(), levels = 50)
+)
+
+## K-fold best fit for LASSO
+lasso_kfold_roc_auc <- lasso_grid |>
+  tune::select_best(metric = "roc_auc")
+
+
+## ----------------------------------------------------------------------------------------------------------------------------------
+## Fit the final LASSO model
+final_lasso_kfold <- tune::finalize_workflow(
+  workflows::add_model(thyroid_workflow, tune_spec_lasso),
+  lasso_kfold_roc_auc)
+
+final_lasso_kfold |>
+  fit(train) |>
+  hardhat::extract_fit_parsnip() |>
+  vip::vi(lambda = lasso_kfold_roc_auc$penalty) |>
+  dplyr::mutate(
+    Importance = abs(Importance),
+    Variable = fct_reorder(Variable, Importance)
+  ) |>
+  ggplot(mapping = aes(x = Importance, y = Variable, fill = Sign)) +
+  geom_col() +
+  dark_theme_minimal()
+ggplot2::ggsave("tmp/lasso_exclude_step_filter_missing.png")
+
+####################################################
+## 2024-07-18 - Testing with an imputed data set
+####################################################
+##
+## Impute data
+imputations = 1
+cores = imputations
+mice_pmm_single <- df_complete |>
+    dplyr::select(-final_pathology) |> ## We deliberately exclude the outcome of interest
+    mice::futuremice(m = imputations, method = "pmm", n.core = cores) |>
+    mice::complete(action = "long", include = FALSE)
+## Bind the final_pathology, removing the .id and .imp columns too and renaming columns
+mice_pmm_single <- cbind(mice_pmm_single, df_complete$final_pathology) |>
+    dplyr::select(-.id)
+colnames(mice_pmm_single) <- stringr::str_replace(colnames(mice_pmm_single), "df_complete\\$", "")
+
+## Split a single imputed data set into train/test
+split <- mice_pmm_single |>
+    dplyr::filter(.imp == 1) |>
+    dplyr::select(-.imp) |>
+    rsample::initial_split(prop = 0.75)
+train <- rsample::training(split)
+test <- rsample::testing(split)
+
+## Setup cross-validation with k-folds (n = 10)
+cv_folds <- rsample::vfold_cv(train, v = 10, repeats = 10)
+
+
+## Setup a recipe and workflow
+thyroid_recipe <- recipes::recipe(final_pathology ~ ., data = train) |>
+  ## @ns-rse 2024-06-14 :
+  ## This step can be used to filter observations with missing data, see the manual pages for more details
+  ## https://recipes.tidymodels.org/reference/step_filter_missing.html
+  recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+  ## @ns-rse 2024-06-14 :
+  ## We first normalise the data _before_ we generate dummies otherwise the dummies, which are numerical, get normalised
+  ## too
+  recipes::step_normalize(recipes::all_numeric_predictors()) |>
+  recipes::step_dummy(recipes::all_nominal_predictors())
+thyroid_workflow <- workflows::workflow() |>
+  workflows::add_recipe(thyroid_recipe)
+
+## Try tuning a LASSO model
+tune_spec_lasso <- parsnip::logistic_reg(penalty = hardhat::tune(), mixture = 1) |>
+  parsnip::set_engine("glmnet")
+
+## Tune the LASSO parameters via cross-validation
+lasso_grid <- tune::tune_grid(
+  object = workflows::add_model(thyroid_workflow, tune_spec_lasso),
+  resamples = cv_folds,
+  grid = dials::grid_regular(penalty(), levels = 50)
+)
+
+## K-fold best fit for LASSO
+lasso_kfold_roc_auc <- lasso_grid |>
+  tune::select_best(metric = "roc_auc")
+
+
+## ----------------------------------------------------------------------------------------------------------------------------------
+## Fit the final LASSO model
+final_lasso_kfold <- tune::finalize_workflow(
+  workflows::add_model(thyroid_workflow, tune_spec_lasso),
+  lasso_kfold_roc_auc)
+
+final_lasso_kfold |>
+  fit(train) |>
+  hardhat::extract_fit_parsnip() |>
+  vip::vi(lambda = lasso_kfold_roc_auc$penalty) |>
+  dplyr::mutate(
+    Importance = abs(Importance),
+    Variable = fct_reorder(Variable, Importance)
+  ) |>
+  ggplot(mapping = aes(x = Importance, y = Variable, fill = Sign)) +
+  geom_col() +
+  dark_theme_minimal()
+ggplot2::ggsave("tmp/lasso_from_imputed.png")
+
+##########################################
+
+## 2024-07-11 - Investigating why Tidymodels aren't using all data
+## Split data into train/test
+split <- rsample::initial_split(df_complete, prop = 0.75)
+train <- rsample::training(split)
+test <- rsample::testing(split)
+
+
+## Setup cross-validation with k-folds (n = 10)
+cv_folds <- rsample::vfold_cv(train, v = 10, repeats = 10)
+
+## Run glm() on subsets of variables
+##
+## Clinical variables
+glm_clin <- glm(final_pathology ~ age_at_scan + gender + incidental_nodule + palpable_nodule +
+    rapid_enlargement + compressive_symptoms + hashimotos_thyroiditis + family_history_thyroid_cancer + exposure_radiation +
+    tsh_value + size_nodule_mm + solitary_nodule + cervical_lymphadenopathy,
+    data = train,
+    family = binomial(link = "logit"))
+summary(glm_clin)
+glm_all
+
+## Biochemical markers
+glm_biochem <- glm(final_pathology ~ age_at_scan + gender + tsh_value + albumin + lymphocytes + monocyte,
+    data = train,
+    family = binomial(link = "logit")
+)
+summary(glm_biochem)
+glm_biochem
+
+## Ultrasound features
+glm_ultrasound <- glm(
+    final_pathology ~ age_at_scan + gender + incidental_nodule + tsh_value + size_nodule_mm +
+        solitary_nodule + cervical_lymphadenopathy + bta_u_classification, # + thy_classification,
+    data = train,
+    family = binomial(link = "logit")
+)
+summary(glm_ultrasound)
+glm_ultrasound
+
+## Saturated model
+glm_all <- glm(
+    final_pathology ~ age_at_scan +
+        gender +
+        incidental_nodule +
+        palpable_nodule +
+        rapid_enlargement +
+        compressive_symptoms +
+        hashimotos_thyroiditis +
+        family_history_thyroid_cancer +
+        ## exposure_radiation +
+        ## tsh_value +
+        size_nodule_mm +
+        solitary_nodule +
+        cervical_lymphadenopathy +
+        ## albumin +
+        ## lymphocytes +
+        ## monocyte +
+        incidental_nodule +
+        size_nodule_mm +
+        solitary_nodule +
+        bta_u_classification,
+    data = train,
+    family = binomial(link = "logit")
+)
+summary(glm_all)
+glm_all
+
+
+## Just incidental and palpable nodules
+glm_incidental_palpable <- glm(
+    final_pathology ~
+        incidental_nodule +
+        palpable_nodule,
+    data = train,
+    family = binomial(link = "logit")
+)
+summary(glm_incidental_palpable)
+glm_incidental_palpable
+
+
+####################################################
+## Lets try out the tidy modelling                ##
+####################################################
+
+## incidental nodule
+glm_incidental <- glm(
+    final_pathology ~ incidental_nodule,
+    data = train,
+    family = binomial(link = "logit")
+)
+summary(glm_incidental)
+glm_incidental
+
+recipe_incidental <- recipes::recipe(final_pathology ~ incidental_nodule, data = train) |>
+  recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+  recipes::step_normalize(recipes::all_numeric_predictors()) |>
+  recipes::step_dummy(recipes::all_nominal_predictors())
+## Workflow
+workflow_incidental <- workflows::workflow() |>
+  workflows::add_recipe(recipe_incidental)
+## Model
+logistic_model <- logistic_reg() |>
+  set_engine("glm")
+log_incidental <- workflow_incidental |>
+  add_model(logistic_model)
+## Fit
+log_incidental_fit <- fit(log_incidental, data = train)
+log_incidental_fit
+
+
+## palpable nodule
+glm_palpable <- glm(
+    final_pathology ~ palpable_nodule,
+    data = train,
+    family = binomial(link = "logit")
+)
+summary(glm_palpable)
+glm_palpable
+
+
+recipe_palpable <- recipes::recipe(final_pathology ~ palpable_nodule, data = train) |>
+  recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+  recipes::step_normalize(recipes::all_numeric_predictors()) |>
+  recipes::step_dummy(recipes::all_nominal_predictors())
+## Workflow
+workflow_palpable <- workflows::workflow() |>
+  workflows::add_recipe(recipe_palpable)
+## Model
+logistic_model <- logistic_reg() |>
+  set_engine("glm")
+log_palpable <- workflow_palpable |>
+  add_model(logistic_model)
+## Fit
+log_palpable_fit <- fit(log_palpable, data = train)
+log_palpable_fit
+
+## incidental nodule and palpable nodule
+glm_incidental_palpable <- glm(
+    final_pathology ~ incidental + palpable_nodule,
+    data = train,
+    family = binomial(link = "logit")
+)
+summary(glm_incidental_palpable)
+glm_incidental_palpable
+
+
+recipe_incidental_palpable <- recipes::recipe(final_pathology ~ incidental_nodule + palpable_nodule, data = train) |>
+  recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+  recipes::step_normalize(recipes::all_numeric_predictors()) |>
+  recipes::step_dummy(recipes::all_nominal_predictors())
+## Workflow
+workflow_incidental_palpable <- workflows::workflow() |>
+  workflows::add_recipe(recipe_incidental_palpable)
+## Model
+logistic_model <- logistic_reg() |>
+  set_engine("glm")
+log_incidental_palpable <- workflow_incidental_palpable |>
+  add_model(logistic_model)
+## Fit
+log_incidental_palpable_fit <- fit(log_incidental_palpable, data = train)
+log_incidental_palpable_fit
+
+
+
+## incidental nodule and age nodule
+glm_age_incidental <- glm(
+    final_pathology ~ age_at_scan+ incidental_nodule,
+    data = train,
+    family = binomial(link = "logit")
+)
+summary(glm_age_incidental)
+glm_age_incidental
+
+
+recipe_age_incidental <- recipes::recipe(final_pathology ~ age_at_scan + incidental_nodule, data = train) |>
+  recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+  recipes::step_normalize(recipes::all_numeric_predictors()) |>
+  recipes::step_dummy(recipes::all_nominal_predictors())
+## Workflow
+workflow_age_incidental <- workflows::workflow() |>
+  workflows::add_recipe(recipe_age_incidental)
+## Model
+logistic_model <- logistic_reg() |>
+  set_engine("glm")
+log_age_incidental <- workflow_age_incidental |>
+  add_model(logistic_model)
+## Fit
+log_age_incidental_fit <- fit(log_age_incidental, data = train)
+log_age_incidental_fit
+
+
+
+## palpable nodule and age nodule
+glm_age_palpable <- glm(
+    final_pathology ~ age_at_scan+ palpable_nodule,
+    data = train,
+    family = binomial(link = "logit")
+)
+summary(glm_age_palpable)
+glm_age_palpable
+
+
+recipe_age_palpable <- recipes::recipe(final_pathology ~ age_at_scan + palpable_nodule, data = train) |>
+  recipes::step_filter_missing(recipes::all_predictors(), threshold = 0) |>
+  recipes::step_normalize(recipes::all_numeric_predictors()) |>
+  recipes::step_dummy(recipes::all_nominal_predictors())
+## Workflow
+workflow_age_palpable <- workflows::workflow() |>
+  workflows::add_recipe(recipe_age_palpable)
+## Model
+logistic_model <- logistic_reg() |>
+  set_engine("glm")
+log_age_palpable <- workflow_age_palpable |>
+  add_model(logistic_model)
+## Fit
+log_age_palpable_fit <- fit(log_age_palpable, data = train)
+log_age_palpable_fit


### PR DESCRIPTION
Initial attempt to define recipes for imputed data sets using purrr.

As mentioned I thought about this and think there is a better approach, this is my first attempt at doing so.

The file `sections/_recipe_imputed.qmd` is included which wraps all the steps in `sections/_recipe.qmd` in
`purrr::map()` calls which are applied to the `mice_cart$imputed` data set (which has had `Original` data set removed,
the `.id` variable stripped and the data split based on `.imp`).

Its not quite there yet but I think this is the proper way to approach using `purrr` rather than writing one big
function to do everything (which whilst possible would be more challenging for you to undertake @mdp21oe).

I've left some notes in `sections/_recipe_imputed.qmd`, look for `!!!!!!`. The first I have copied here as its
important...

I'm new to using purrr but from what I can work out/understand so far and the way we want to use it we start with a
dataset that is piped into purrr::map() the first thing we do is then define how we will refer to this dataset using
the notation `\(<some_name>)` we then provide a function we wish to apply to each split of the data and use
`<some_name>` as an argument to that function.