### PR TITLE
results: Print more results across all models

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -364,25 +364,25 @@ data across all co-variates imputed datasets were analysed instead.
 
 <!-- OLD {{< include sections/_lasso.qmd >}} -->
 
-<!-- {{< include sections/_lasso_imputed.qmd >}} -->
+{{< include sections/_lasso_imputed.qmd >}}
 
 #### Elastic Net
 
 <!-- OLD {{< include sections/_elastic.qmd >}} -->
 
-<!-- {{< include sections/_elastic_imputed.qmd >}} -->
+{{< include sections/_elastic_imputed.qmd >}}
 
 #### Random Forest
 
 <!-- OLD {{< include sections/_rforest.qmd >}} -->
 
-<!-- {{< include sections/_forest_imputed.qmd >}} -->
+{{< include sections/_forest_imputed.qmd >}}
 
 #### Gradient Boosting
 
 <!-- OLD {{< include sections/_xgboost.qmd >}} -->
 
-<!-- {{< include sections/_xgboost_imputed.qmd >}} -->
+{{< include sections/_xgboost_imputed.qmd >}}
 
 
 #### Explainability

--- a/r/functions.R
+++ b/r/functions.R
@@ -31,9 +31,15 @@ model_fitting <- function(df,
                           repeats = 10,
                           missing_threshold = 0.0,
                           outcome = "final_pathology",
-                          continuous = c("albumin", "tsh_value", "lymphocytes", "monocyte", "size_nodule_mm"),
+                          continuous = c(
+                              # "albumin",
+                              "tsh_value",
+                              "lymphocytes",
+                              "monocyte",
+                              "size_nodule_mm"
+                          ),
                           categorical = c(
-                              "ethnicity",
+                              # "ethnicity",
                               "incidental_nodule",
                               "palpable_nodule",
                               "rapid_enlargement",
@@ -148,7 +154,7 @@ model_fitting <- function(df,
                              metrics = yardstick_metrics,
                              control = control
                          )
-    ## Select the best model based on ROC Area Under the Curve and finalise the workflow by adding the tunde model and
+    ## Select the best model based on ROC Area Under the Curve and finalise the workflow by adding the tuned model and
     ## best metric fit
     best_metric_fit <- tuned_model |>
         tune::select_best()
@@ -171,7 +177,8 @@ model_fitting <- function(df,
     importance_plot <- importance |>
         ggplot2::ggplot(mapping = aes(x = Importance, y = Variable, fill = Sign)) +
         ggplot2::geom_col() +
-        ggdark::dark_theme_minimal()
+        ggdark::dark_theme_minimal() +
+        ggplot2::ggtitle("Train")
     ########################################################
     ## Summarise model on train data set                  ##
     ########################################################
@@ -200,7 +207,8 @@ model_fitting <- function(df,
         ggplot2::geom_path() +
         ggplot2::geom_abline(lty = 3) +
         ggplot2::coord_equal() +
-        ggdark::dark_theme_minimal()
+        ggdark::dark_theme_minimal() +
+        ggplot2::ggtitle("Train")
     ########################################################
     ## Summarise model on test data set                   ##
     ########################################################
@@ -229,7 +237,8 @@ model_fitting <- function(df,
         ggplot2::geom_path() +
         ggplot2::geom_abline(lty = 3) +
         ggplot2::coord_equal() +
-        ggdark::dark_theme_minimal()
+        ggdark::dark_theme_minimal() +
+        ggplot2::ggtitle("Test")
     ## Combine results into a single list for returning
     results <- list()
     results$train <- train

--- a/sections/_elastic_imputed.qmd
+++ b/sections/_elastic_imputed.qmd
@@ -1,5 +1,5 @@
 ``` {r}
-#| label: fig-imputed-pmm-elastic
+#| label: load-imputed-pmm-elastic
 #| purl: true
 #| eval: true
 #| echo: false
@@ -111,6 +111,46 @@ cowplot::plot_grid(imputed_cart_model_elastic[[1]]$importance_plot,
 
 ```
 
+
+``` {r}
+#| label: tab-imputed-cart-elastic-importance
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Importance of features from LASSO model of five CART imputed datasets."
+tidy_cart_elastic$importance |>
+    knitr::kable(caption = "Importance of features from LASSO model of five CART imputed datasets.")
+
+```
+
+``` {r}
+#| label: tab-imputed-cart-elastic-train-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five CART imputed datasets (Training Data)."
+tidy_cart_elastic$train_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five CART imputed datasets (Training Data).",
+                 digits = 4)
+
+```
+
+``` {r}
+#| label: tab-imputed-cart-elastic-test-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five CART imputed datasets (Testing Data)."
+tidy_cart_elastic$test_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five CART imputed datasets (Testing Data).",
+                 digits = 4)
+
+```
+
+
 ## Random Forest
 
 ``` {r}
@@ -138,6 +178,45 @@ cowplot::plot_grid(imputed_rf_model_elastic[[1]]$importance_plot,
                    # labels = c("PMM", "Rf", "Random Forest"),
                    nrow = 5,
                    ncol = 3)
+
+```
+
+
+``` {r}
+#| label: tab-imputed-rf-elastic-importance
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Importance of features from LASSO model of five RF imputed datasets."
+tidy_rf_elastic$importance |>
+    knitr::kable(caption = "Importance of features from LASSO model of five RF imputed datasets.")
+
+```
+
+``` {r}
+#| label: tab-imputed-rf-elastic-train-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five RF imputed datasets (Training Data)."
+tidy_rf_elastic$train_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five RF imputed datasets (Training Data).",
+                 digits = 4)
+
+```
+
+``` {r}
+#| label: tab-imputed-rf-elastic-test-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five RF imputed datasets (Testing Data)."
+tidy_rf_elastic$test_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five RF imputed datasets (Testing Data).",
+                 digits = 4)
 
 ```
 

--- a/sections/_forest_imputed.qmd
+++ b/sections/_forest_imputed.qmd
@@ -1,5 +1,5 @@
 ``` {r}
-#| label: fig-imputed-pmm-forest
+#| label: load-imputed-pmm-forest
 #| purl: true
 #| eval: true
 #| echo: false
@@ -111,6 +111,45 @@ cowplot::plot_grid(imputed_cart_model_forest[[1]]$importance_plot,
 
 ```
 
+``` {r}
+#| label: tab-imputed-cart-forest-importance
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Importance of features from LASSO model of five CART imputed datasets."
+tidy_cart_forest$importance |>
+    knitr::kable(caption = "Importance of features from LASSO model of five CART imputed datasets.")
+
+```
+
+``` {r}
+#| label: tab-imputed-cart-forest-train-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five CART imputed datasets (Training Data)."
+tidy_cart_forest$train_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five CART imputed datasets (Training Data).",
+                 digits = 4)
+
+```
+
+``` {r}
+#| label: tab-imputed-cart-forest-test-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five CART imputed datasets (Testing Data)."
+tidy_cart_forest$test_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five CART imputed datasets (Testing Data).",
+                 digits = 4)
+
+```
+
+
 ## Random Forest
 
 ``` {r}
@@ -138,6 +177,45 @@ cowplot::plot_grid(imputed_rf_model_forest[[1]]$importance_plot,
                    # labels = c("PMM", "Rf", "Random Forest"),
                    nrow = 5,
                    ncol = 3)
+
+```
+
+
+``` {r}
+#| label: tab-imputed-rf-forest-importance
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Importance of features from LASSO model of five RF imputed datasets."
+tidy_rf_forest$importance |>
+    knitr::kable(caption = "Importance of features from LASSO model of five RF imputed datasets.")
+
+```
+
+``` {r}
+#| label: tab-imputed-rf-forest-train-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five RF imputed datasets (Training Data)."
+tidy_rf_forest$train_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five RF imputed datasets (Training Data).",
+                 digits = 4)
+
+```
+
+``` {r}
+#| label: tab-imputed-rf-forest-test-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five RF imputed datasets (Testing Data)."
+tidy_rf_forest$test_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five RF imputed datasets (Testing Data).",
+                 digits = 4)
 
 ```
 

--- a/sections/_lasso_imputed.qmd
+++ b/sections/_lasso_imputed.qmd
@@ -1,5 +1,5 @@
 ``` {r}
-#| label: fig-imputed-pmm-lasso
+#| label: load-imputed-pmm-lasso
 #| purl: true
 #| eval: true
 #| echo: false
@@ -111,6 +111,44 @@ cowplot::plot_grid(imputed_cart_model_lasso[[1]]$importance_plot,
 
 ```
 
+``` {r}
+#| label: tab-imputed-cart-lasso-importance
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Importance of features from LASSO model of five CART imputed datasets."
+tidy_cart_lasso$importance |>
+    knitr::kable(caption = "Importance of features from LASSO model of five CART imputed datasets.")
+
+```
+
+``` {r}
+#| label: tab-imputed-cart-lasso-train-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five CART imputed datasets (Training Data)."
+tidy_cart_lasso$train_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five CART imputed datasets (Training Data).",
+                 digits = 4)
+
+```
+
+``` {r}
+#| label: tab-imputed-cart-lasso-test-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five CART imputed datasets (Testing Data)."
+tidy_cart_lasso$test_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five CART imputed datasets (Testing Data).",
+                 digits = 4)
+
+```
+
 ## Random Forest
 
 ``` {r}
@@ -141,4 +179,42 @@ cowplot::plot_grid(imputed_rf_model_lasso[[1]]$importance_plot,
 
 ```
 
+
+``` {r}
+#| label: tab-imputed-rf-lasso-importance
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Importance of features from LASSO model of five RF imputed datasets."
+tidy_rf_lasso$importance |>
+    knitr::kable(caption = "Importance of features from LASSO model of five RF imputed datasets.")
+
+```
+
+``` {r}
+#| label: tab-imputed-rf-lasso-train-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five RF imputed datasets (Training Data)."
+tidy_rf_lasso$train_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five RF imputed datasets (Training Data).",
+                 digits = 4)
+
+```
+
+``` {r}
+#| label: tab-imputed-rf-lasso-test-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five RF imputed datasets (Testing Data)."
+tidy_rf_lasso$test_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five RF imputed datasets (Testing Data).",
+                 digits = 4)
+
+```
 :::

--- a/sections/_xgboost_imputed.qmd
+++ b/sections/_xgboost_imputed.qmd
@@ -1,5 +1,5 @@
 ``` {r}
-#| label: fig-imputed-pmm-xgboost
+#| label: load-imputed-pmm-xgboost
 #| purl: true
 #| eval: true
 #| echo: false
@@ -111,6 +111,44 @@ cowplot::plot_grid(imputed_cart_model_xgboost[[1]]$importance_plot,
 
 ```
 
+``` {r}
+#| label: tab-imputed-cart-xgboost-importance
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Importance of features from LASSO model of five CART imputed datasets."
+tidy_cart_xgboost$importance |>
+    knitr::kable(caption = "Importance of features from LASSO model of five CART imputed datasets.")
+
+```
+
+``` {r}
+#| label: tab-imputed-cart-xgboost-train-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five CART imputed datasets (Training Data)."
+tidy_cart_xgboost$train_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five CART imputed datasets (Training Data).",
+                 digits = 4)
+
+```
+
+``` {r}
+#| label: tab-imputed-cart-xgboost-test-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five CART imputed datasets (Testing Data)."
+tidy_cart_xgboost$test_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five CART imputed datasets (Testing Data).",
+                 digits = 4)
+
+```
+
 ## Random Forest
 
 ``` {r}
@@ -138,6 +176,44 @@ cowplot::plot_grid(imputed_rf_model_xgboost[[1]]$importance_plot,
                    # labels = c("PMM", "Rf", "Random Forest"),
                    nrow = 5,
                    ncol = 3)
+
+```
+
+``` {r}
+#| label: tab-imputed-rf-xgboost-importance
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Importance of features from LASSO model of five RF imputed datasets."
+tidy_rf_xgboost$importance |>
+    knitr::kable(caption = "Importance of features from LASSO model of five RF imputed datasets.")
+
+```
+
+``` {r}
+#| label: tab-imputed-rf-xgboost-train-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five RF imputed datasets (Training Data)."
+tidy_rf_xgboost$train_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five RF imputed datasets (Training Data).",
+                 digits = 4)
+
+```
+
+``` {r}
+#| label: tab-imputed-rf-xgboost-test-metrics
+#| purl: true
+#| eval: true
+#| echo: false
+#| output: true
+#| tbl-caption: "Classification metrics from LASSO model of five RF imputed datasets (Testing Data)."
+tidy_rf_xgboost$test_metrics |>
+    knitr::kable(caption = "Classification metrics from LASSO model of five RF imputed datasets (Testing Data).",
+                 digits = 4)
 
 ```
 


### PR DESCRIPTION
Tabulates more results across all models. These have been pushed to `gh-pages` and render at
https://blog.nshephard.dev/sheffield-thyroid/ although when I change ownershipt to `mdp21oe` that URL will change to
https://mdp21oe.github.io/sheffield-thyroid/